### PR TITLE
Validate typography wordSpacing keyword

### DIFF
--- a/tests/fixtures/negative/word-spacing-invalid-keyword/expected.error.json
+++ b/tests/fixtures/negative/word-spacing-invalid-keyword/expected.error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "E_INVALID_KEYWORD",
+    "path": "/typography/bad/$value/wordSpacing",
+    "message": "invalid keyword"
+  }
+}

--- a/tests/fixtures/negative/word-spacing-invalid-keyword/input.json
+++ b/tests/fixtures/negative/word-spacing-invalid-keyword/input.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "typography": {
+    "bad": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
+        "wordSpacing": "wide"
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/word-spacing-invalid-keyword/meta.yaml
+++ b/tests/fixtures/negative/word-spacing-invalid-keyword/meta.yaml
@@ -1,0 +1,5 @@
+name: word-spacing-invalid-keyword
+description: unrecognised wordSpacing keyword
+assertions:
+  - type-compat
+tags: [typography]

--- a/tests/fixtures/positive/typography-optional-fields/expected.json
+++ b/tests/fixtures/positive/typography-optional-fields/expected.json
@@ -1,5 +1,18 @@
 {
   "typography": {
+    "keywordNormal": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 16,
+          "unit": "px"
+        },
+        "wordSpacing": "normal"
+      }
+    },
     "optional": {
       "$type": "typography",
       "$value": {

--- a/tests/fixtures/positive/typography-optional-fields/input.json
+++ b/tests/fixtures/positive/typography-optional-fields/input.json
@@ -1,6 +1,19 @@
 {
   "$schema": "https://dtif.lapidist.net/schema/core.json",
   "typography": {
+    "keywordNormal": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 16,
+          "unit": "px"
+        },
+        "wordSpacing": "normal"
+      }
+    },
     "optional": {
       "$type": "typography",
       "$value": {

--- a/tests/tooling/assert-type-compat.mjs
+++ b/tests/tooling/assert-type-compat.mjs
@@ -478,6 +478,14 @@ export default function assertTypeCompat(doc) {
             message: 'invalid keyword'
           });
         }
+        const ws = node.$value.wordSpacing;
+        if (typeof ws === 'string' && ws !== 'normal') {
+          errors.push({
+            code: 'E_INVALID_KEYWORD',
+            path: `${path}/$value/wordSpacing`,
+            message: 'invalid keyword'
+          });
+        }
         const fw = node.$value.fontWeight;
         if (typeof fw === 'string' && !CSS_FONT_WEIGHT_KEYWORDS.has(fw)) {
           errors.push({


### PR DESCRIPTION
## Summary
- flag `wordSpacing` strings other than `normal` during typography type compatibility checks
- add a negative fixture exercising the new `wordSpacing` keyword validation
- extend the typography optional fields fixture to cover the `normal` keyword pass case

## Testing
- npm run format
- node tests/tooling/run.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cca0ef721c832891d90894c52c7db2