### PR TITLE
Allow typography string font weights

### DIFF
--- a/tests/fixtures/positive/font-weight-string/expected.json
+++ b/tests/fixtures/positive/font-weight-string/expected.json
@@ -1,0 +1,56 @@
+{
+  "typography": {
+    "stringNumeric": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontWeight": "600",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 16,
+          "unit": "px"
+        }
+      }
+    },
+    "stringRange": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontWeight": "400 700",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 18,
+          "unit": "px"
+        }
+      }
+    },
+    "stringSignedNumeric": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontWeight": "+500",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 20,
+          "unit": "px"
+        }
+      }
+    },
+    "stringSignedRange": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontWeight": "+300 700",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 22,
+          "unit": "px"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/font-weight-string/input.json
+++ b/tests/fixtures/positive/font-weight-string/input.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "typography": {
+    "stringNumeric": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontWeight": "600",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 16,
+          "unit": "px"
+        }
+      }
+    },
+    "stringRange": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontWeight": "400 700",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 18,
+          "unit": "px"
+        }
+      }
+    },
+    "stringSignedNumeric": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontWeight": "+500",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 20,
+          "unit": "px"
+        }
+      }
+    },
+    "stringSignedRange": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontWeight": "+300 700",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 22,
+          "unit": "px"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/font-weight-string/meta.yaml
+++ b/tests/fixtures/positive/font-weight-string/meta.yaml
@@ -1,0 +1,7 @@
+name: font-weight-string
+description: typography tokens with string fontWeight values
+assertions:
+  - schema
+  - type-compat
+  - refs
+tags: [typography]


### PR DESCRIPTION
## Summary
- expand the type compatibility helper to accept signed CSS-compliant string font weights alongside numeric strings and ranges
- extend the positive typography fixture with signed numeric and range-based `fontWeight` examples to guard the behaviour

## Testing
- npm run format
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc9b8e13e083288a4b75818fa4a3c2