### PR TITLE
Restrict wordSpacing dimensions to length

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -709,7 +709,7 @@
         "wordSpacing": {
           "$comment": "MUST conform to CSS word-spacing <length-percentage> grammar and platform unit semantics.",
           "oneOf": [
-            { "$ref": "#/$defs/dimension" },
+            { "$ref": "#/$defs/font-dimension" },
             {
               "type": "string",
               "$comment": "MUST be the keyword 'normal' per CSS Text Module Level 3 word-spacing grammar."

--- a/tests/fixtures/negative/word-spacing-invalid-dimension-type/expected.error.json
+++ b/tests/fixtures/negative/word-spacing-invalid-dimension-type/expected.error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "E_WORD_SPACING_DIMENSION_TYPE",
+    "path": "/typography/bad/$value/wordSpacing/dimensionType",
+    "message": "wordSpacing dimensionType must be \"length\""
+  }
+}

--- a/tests/fixtures/negative/word-spacing-invalid-dimension-type/input.json
+++ b/tests/fixtures/negative/word-spacing-invalid-dimension-type/input.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "typography": {
+    "bad": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
+        "wordSpacing": { "dimensionType": "angle", "value": 10, "unit": "deg" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/word-spacing-invalid-dimension-type/meta.yaml
+++ b/tests/fixtures/negative/word-spacing-invalid-dimension-type/meta.yaml
@@ -1,0 +1,5 @@
+name: word-spacing-invalid-dimension-type
+description: wordSpacing must use length dimensions
+assertions:
+  - type-compat
+tags: [typography]

--- a/tests/fixtures/positive/typography-optional-fields/expected.json
+++ b/tests/fixtures/positive/typography-optional-fields/expected.json
@@ -53,8 +53,8 @@
         },
         "wordSpacing": {
           "dimensionType": "length",
-          "value": 2,
-          "unit": "px"
+          "value": 5,
+          "unit": "%"
         }
       }
     }

--- a/tests/fixtures/positive/typography-optional-fields/input.json
+++ b/tests/fixtures/positive/typography-optional-fields/input.json
@@ -54,8 +54,8 @@
         },
         "wordSpacing": {
           "dimensionType": "length",
-          "value": 2,
-          "unit": "px"
+          "value": 5,
+          "unit": "%"
         }
       }
     }

--- a/tests/tooling/assert-type-compat.mjs
+++ b/tests/tooling/assert-type-compat.mjs
@@ -528,12 +528,23 @@ export default function assertTypeCompat(doc) {
           });
         }
         const ws = node.$value.wordSpacing;
-        if (typeof ws === 'string' && ws !== 'normal') {
-          errors.push({
-            code: 'E_INVALID_KEYWORD',
-            path: `${path}/$value/wordSpacing`,
-            message: 'invalid keyword'
-          });
+        if (typeof ws === 'string') {
+          if (ws !== 'normal') {
+            errors.push({
+              code: 'E_INVALID_KEYWORD',
+              path: `${path}/$value/wordSpacing`,
+              message: 'invalid keyword'
+            });
+          }
+        } else if (ws && typeof ws === 'object') {
+          const dimensionType = ws.dimensionType;
+          if (typeof dimensionType === 'string' && dimensionType !== 'length') {
+            errors.push({
+              code: 'E_WORD_SPACING_DIMENSION_TYPE',
+              path: `${path}/$value/wordSpacing/dimensionType`,
+              message: 'wordSpacing dimensionType must be "length"'
+            });
+          }
         }
         const fw = node.$value.fontWeight;
         if (typeof fw === 'string' && !isValidFontWeightString(fw)) {


### PR DESCRIPTION
## Summary
- require typography `wordSpacing` dimensions to use the `font-dimension` schema
- flag non-`normal` `wordSpacing` keywords and non-length dimensions in the type-compat validator
- cover valid and invalid `wordSpacing` dimensions with new fixtures

## Testing
- npm run format
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cca2bbf37c8328a18826a771a4e6db