### PR TITLE
Validate fontFace fontWeight strings

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -538,6 +538,11 @@
       },
       "additionalProperties": false
     },
+    "font-weight-string": {
+      "type": "string",
+      "pattern": "^(?:[Bb][Oo][Ll][Dd][Ee][Rr]|[Ll][Ii][Gg][Hh][Tt][Ee][Rr]|(?:[Nn][Oo][Rr][Mm][Aa][Ll]|[Bb][Oo][Ll][Dd]|\\+?(?:0*(?:[1-9]\\d{0,2})(?:\\.\\d+)?|0*1000(?:\\.0+)?))(?:\\s+(?:[Nn][Oo][Rr][Mm][Aa][Ll]|[Bb][Oo][Ll][Dd]|\\+?(?:0*(?:[1-9]\\d{0,2})(?:\\.\\d+)?|0*1000(?:\\.0+)?)))?)$",
+      "$comment": "String weights MUST conform to CSS <font-weight-absolute>, <font-weight-relative>, or <font-weight-range> productions (css-fonts-4)."
+    },
     "font": {
       "type": "object",
       "required": ["fontType", "family"],
@@ -564,10 +569,7 @@
               "maximum": 1000,
               "$comment": "Numeric weights MUST follow the 1..1000 range defined by CSS Fonts (css-fonts-4)."
             },
-            {
-              "type": "string",
-              "$comment": "String weights MUST conform to CSS <font-weight-absolute>, <font-weight-relative>, or <font-weight-range> productions (css-fonts-4)."
-            }
+            { "$ref": "#/$defs/font-weight-string" }
           ]
         }
       },
@@ -637,10 +639,7 @@
               "maximum": 1000,
               "$comment": "Numeric weights MUST follow the 1..1000 range defined by CSS Fonts (css-fonts-4)."
             },
-            {
-              "type": "string",
-              "$comment": "String weights MUST conform to CSS <font-weight-absolute>, <font-weight-relative>, or <font-weight-range> productions (css-fonts-4)."
-            }
+            { "$ref": "#/$defs/font-weight-string" }
           ]
         },
         "fontStyle": {
@@ -725,10 +724,7 @@
               "maximum": 1000,
               "$comment": "MUST be within the CSS absolute weight range of 1-1000 and MAY include fractional values for variable fonts."
             },
-            {
-              "type": "string",
-              "$comment": "MUST conform to CSS font-weight keyword grammar including relative weights."
-            }
+            { "$ref": "#/$defs/font-weight-string" }
           ]
         },
         "fontStyle": {

--- a/tests/fixtures/negative/font-face-invalid-weight/expected.error.json
+++ b/tests/fixtures/negative/font-face-invalid-weight/expected.error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "E_INVALID_KEYWORD",
+    "path": "/fontFace/bad/$value/fontWeight",
+    "message": "invalid keyword"
+  }
+}

--- a/tests/fixtures/negative/font-face-invalid-weight/input.json
+++ b/tests/fixtures/negative/font-face-invalid-weight/input.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "fontFace": {
+    "bad": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Example Sans",
+        "src": [{ "local": "Example Sans" }],
+        "fontWeight": "semi-bold"
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/font-face-invalid-weight/meta.yaml
+++ b/tests/fixtures/negative/font-face-invalid-weight/meta.yaml
@@ -1,0 +1,6 @@
+name: font-face-invalid-weight
+description: fontFace tokens reject invalid fontWeight keywords
+assertions:
+  - type-compat
+tags:
+  - fontFace

--- a/tests/fixtures/positive/font-face-string-weight/expected.json
+++ b/tests/fixtures/positive/font-face-string-weight/expected.json
@@ -1,0 +1,25 @@
+{
+  "fontFace": {
+    "keyword": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Example Sans",
+        "src": [{ "local": "Example Sans" }],
+        "fontWeight": "bold"
+      }
+    },
+    "range": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Example Sans Variable",
+        "src": [
+          {
+            "url": "https://cdn.example.com/fonts/ExampleSansVariable.woff2",
+            "format": "woff2"
+          }
+        ],
+        "fontWeight": "400 700"
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/font-face-string-weight/input.json
+++ b/tests/fixtures/positive/font-face-string-weight/input.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "fontFace": {
+    "keyword": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Example Sans",
+        "src": [{ "local": "Example Sans" }],
+        "fontWeight": "bold"
+      }
+    },
+    "range": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Example Sans Variable",
+        "src": [
+          {
+            "url": "https://cdn.example.com/fonts/ExampleSansVariable.woff2",
+            "format": "woff2"
+          }
+        ],
+        "fontWeight": "400 700"
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/font-face-string-weight/meta.yaml
+++ b/tests/fixtures/positive/font-face-string-weight/meta.yaml
@@ -1,0 +1,9 @@
+name: font-face-string-weight
+description: fontFace tokens accept CSS font-weight keywords and ranges
+assertions:
+  - schema
+  - type-compat
+  - refs
+  - roundtrip
+tags:
+  - fontFace

--- a/tests/tooling/assert-type-compat.mjs
+++ b/tests/tooling/assert-type-compat.mjs
@@ -518,6 +518,16 @@ export default function assertTypeCompat(doc) {
           }
         }
       }
+      if (node.$type === 'fontFace' && node.$value && typeof node.$value === 'object') {
+        const fw = node.$value.fontWeight;
+        if (typeof fw === 'string' && !isValidFontWeightString(fw)) {
+          errors.push({
+            code: 'E_INVALID_KEYWORD',
+            path: `${path}/$value/fontWeight`,
+            message: 'invalid keyword'
+          });
+        }
+      }
       if (node.$type === 'typography' && node.$value && typeof node.$value === 'object') {
         const ls = node.$value.letterSpacing;
         if (typeof ls === 'string' && ls !== 'normal') {


### PR DESCRIPTION
## Summary
- enforce CSS-compliant fontWeight strings with a shared schema rule reused by font, fontFace, and typography tokens
- extend the type-compatibility guard so fontFace tokens reject invalid fontWeight keywords
- add regression fixtures covering invalid and valid fontFace fontWeight strings

## Testing
- npm run format
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cca5e4a83c8328bf72a2bc5ca59657