### PR TITLE
Ensure typography fontSize uses length dimensions

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -682,7 +682,7 @@
             }
           ]
         },
-        "fontSize": { "$ref": "#/$defs/dimension" },
+        "fontSize": { "$ref": "#/$defs/font-dimension" },
         "lineHeight": {
           "description": "Baseline-to-baseline distance as a ratio or font-dimension.",
           "oneOf": [

--- a/tests/fixtures/negative/font-size-invalid-dimension-type/expected.error.json
+++ b/tests/fixtures/negative/font-size-invalid-dimension-type/expected.error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "E_FONT_SIZE_DIMENSION_TYPE",
+    "path": "/typography/bad/$value/fontSize/dimensionType",
+    "message": "fontSize dimensionType must be \"length\""
+  }
+}

--- a/tests/fixtures/negative/font-size-invalid-dimension-type/input.json
+++ b/tests/fixtures/negative/font-size-invalid-dimension-type/input.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "typography": {
+    "bad": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontSize": { "dimensionType": "angle", "value": 12, "unit": "deg" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/font-size-invalid-dimension-type/meta.yaml
+++ b/tests/fixtures/negative/font-size-invalid-dimension-type/meta.yaml
@@ -1,0 +1,5 @@
+name: font-size-invalid-dimension-type
+description: fontSize must use length dimensions
+assertions:
+  - type-compat
+tags: [typography]

--- a/tests/tooling/assert-type-compat.mjs
+++ b/tests/tooling/assert-type-compat.mjs
@@ -529,6 +529,16 @@ export default function assertTypeCompat(doc) {
         }
       }
       if (node.$type === 'typography' && node.$value && typeof node.$value === 'object') {
+        const fontSize = node.$value.fontSize;
+        if (fontSize && typeof fontSize === 'object' && !Array.isArray(fontSize)) {
+          if (fontSize.dimensionType !== 'length') {
+            errors.push({
+              code: 'E_FONT_SIZE_DIMENSION_TYPE',
+              path: `${path}/$value/fontSize/dimensionType`,
+              message: 'fontSize dimensionType must be "length"'
+            });
+          }
+        }
         const ls = node.$value.letterSpacing;
         if (typeof ls === 'string' && ls !== 'normal') {
           errors.push({


### PR DESCRIPTION
## Summary
- require typography token fontSize values to use the shared font-dimension schema
- surface a dedicated error when typography fontSize dimensions are missing or not lengths
- add a regression fixture covering a typography fontSize defined with an angle dimension

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd0887d5ac8328a2d78786cfef4510