### PR TITLE
Allow fractional fontFace weights

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -634,7 +634,7 @@
         "fontWeight": {
           "oneOf": [
             {
-              "type": "integer",
+              "type": "number",
               "minimum": 1,
               "maximum": 1000,
               "$comment": "Numeric weights MUST follow the 1..1000 range defined by CSS Fonts (css-fonts-4)."

--- a/tests/fixtures/positive/font-face/expected.json
+++ b/tests/fixtures/positive/font-face/expected.json
@@ -4,7 +4,7 @@
       "$type": "fontFace",
       "$value": {
         "fontFamily": "Brand Sans",
-        "fontWeight": 400,
+        "fontWeight": 365.5,
         "fontStyle": "normal",
         "fontStretch": "semi-expanded",
         "unicodeRange": "U+000-5FF, U+13A0-13F5",

--- a/tests/fixtures/positive/font-face/input.json
+++ b/tests/fixtures/positive/font-face/input.json
@@ -5,7 +5,7 @@
       "$type": "fontFace",
       "$value": {
         "fontFamily": "Brand Sans",
-        "fontWeight": 400,
+        "fontWeight": 365.5,
         "fontStyle": "normal",
         "fontStretch": "semi-expanded",
         "unicodeRange": "U+000-5FF, U+13A0-13F5",


### PR DESCRIPTION
## Summary
- allow numeric fontFace fontWeight values to be non-integers while keeping the CSS range constraints
- cover fractional fontWeight values in the positive font-face fixture expectations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd0bbbd65c8328a1076d06d9416e0b