### PR TITLE
Allow fractional numeric font weights

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -564,7 +564,7 @@
         "weight": {
           "oneOf": [
             {
-              "type": "integer",
+              "type": "number",
               "minimum": 1,
               "maximum": 1000,
               "$comment": "Numeric weights MUST follow the 1..1000 range defined by CSS Fonts (css-fonts-4)."

--- a/tests/fixtures/positive/font/expected.json
+++ b/tests/fixtures/positive/font/expected.json
@@ -6,7 +6,7 @@
         "fontType": "css.font-face",
         "family": "Example Display",
         "style": "oblique 10deg",
-        "weight": 600
+        "weight": 375.5
       }
     },
     "sans": {

--- a/tests/fixtures/positive/font/input.json
+++ b/tests/fixtures/positive/font/input.json
@@ -7,7 +7,7 @@
         "fontType": "css.font-face",
         "family": "Example Display",
         "style": "oblique 10deg",
-        "weight": 600
+        "weight": 375.5
       }
     },
     "sans": {


### PR DESCRIPTION
## Summary
- allow numeric font weights to be numbers so schemas accept fractional values
- update the positive font fixture to verify fractional weight handling

## Testing
- npm test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cd0d47b9dc8328a8aebfa2d2f039a1