### PR TITLE
Enforce fontDisplay keywords

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -657,6 +657,7 @@
         },
         "fontDisplay": {
           "type": "string",
+          "pattern": "^(?:[Aa][Uu][Tt][Oo]|[Bb][Ll][Oo][Cc][Kk]|[Ss][Ww][Aa][Pp]|[Ff][Aa][Ll][Ll][Bb][Aa][Cc][Kk]|[Oo][Pp][Tt][Ii][Oo][Nn][Aa][Ll])$",
           "$comment": "Display strategy MUST use the css-fonts-4 font-display keywords; native runtimes map these hints to preload/async policies."
         }
       },

--- a/tests/fixtures/negative/font-face-invalid-display/expected.error.json
+++ b/tests/fixtures/negative/font-face-invalid-display/expected.error.json
@@ -1,0 +1,5 @@
+{
+  "error": {
+    "message": "must match pattern \"^(?:[Aa][Uu][Tt][Oo]|[Bb][Ll][Oo][Cc][Kk]|[Ss][Ww][Aa][Pp]|[Ff][Aa][Ll][Ll][Bb][Aa][Cc][Kk]|[Oo][Pp][Tt][Ii][Oo][Nn][Aa][Ll])$\""
+  }
+}

--- a/tests/fixtures/negative/font-face-invalid-display/input.json
+++ b/tests/fixtures/negative/font-face-invalid-display/input.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "fontFace": {
+    "bad": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Example Sans",
+        "src": [{ "local": "Example Sans" }],
+        "fontDisplay": "instant"
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/font-face-invalid-display/meta.yaml
+++ b/tests/fixtures/negative/font-face-invalid-display/meta.yaml
@@ -1,0 +1,6 @@
+name: font-face-invalid-display
+description: fontFace tokens reject unsupported fontDisplay keywords
+assertions:
+  - schema
+tags:
+  - fontFace


### PR DESCRIPTION
## Summary
- restrict `fontFace.properties.fontDisplay` to the standard `font-display` keywords using a case-insensitive pattern check
- add a negative fixture that exercises an unsupported `fontDisplay` value to ensure schema validation fails

## Testing
- node tests/tooling/run.mjs

------
https://chatgpt.com/codex/tasks/task_e_68cd0ea25948832881f3dacb311514d0