### PR TITLE
Enforce length-only dimensions for shadow tokens

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -847,19 +847,19 @@
           "$comment": "MUST identify the rendering context defined by CSS <shadow> grammars, UIKit CALayer/NSShadow APIs, or Android View/Paint shadow documentation (e.g. css.box-shadow, css.text-shadow, css.filter.drop-shadow, ios.layer, ios.text, android.view.elevation)."
         },
         "offsetX": {
-          "$ref": "#/$defs/dimension",
+          "$ref": "#/$defs/length-dimension",
           "$comment": "Horizontal offset MUST conform to CSS <length> or platform-native units such as points (pt) and density-independent pixels (dp)."
         },
         "offsetY": {
-          "$ref": "#/$defs/dimension",
+          "$ref": "#/$defs/length-dimension",
           "$comment": "Vertical offset MUST conform to CSS <length> or platform-native units such as points (pt) and density-independent pixels (dp)."
         },
         "blur": {
-          "$ref": "#/$defs/dimension",
+          "$ref": "#/$defs/length-dimension",
           "$comment": "Blur radius MUST match the <length> position in the CSS <shadow> production or equivalent CALayer.shadowRadius / Paint#setShadowLayer radius semantics."
         },
         "spread": {
-          "$ref": "#/$defs/dimension",
+          "$ref": "#/$defs/length-dimension",
           "$comment": "Optional spread MUST follow the final <length> of CSS <shadow> and is realised via CALayer.shadowPath or Android outline inflation."
         },
         "color": {

--- a/tests/fixtures/negative/shadow-invalid-dimension/expected.error.json
+++ b/tests/fixtures/negative/shadow-invalid-dimension/expected.error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "E_SHADOW_DIMENSION_TYPE",
+    "path": "/shadow/bad/$value/offsetX/dimensionType",
+    "message": "offsetX dimensionType must be \"length\""
+  }
+}

--- a/tests/fixtures/negative/shadow-invalid-dimension/input.json
+++ b/tests/fixtures/negative/shadow-invalid-dimension/input.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "shadow": {
+    "bad": {
+      "$type": "shadow",
+      "$value": {
+        "shadowType": "css.box-shadow",
+        "offsetX": { "dimensionType": "angle", "value": 2, "unit": "deg" },
+        "offsetY": { "dimensionType": "length", "value": 1, "unit": "px" },
+        "blur": { "dimensionType": "length", "value": 4, "unit": "px" },
+        "spread": { "value": 1, "unit": "px" },
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0, 0.4]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/shadow-invalid-dimension/meta.yaml
+++ b/tests/fixtures/negative/shadow-invalid-dimension/meta.yaml
@@ -1,0 +1,6 @@
+name: shadow-invalid-dimension
+description: shadow dimensions must use length units
+assertions:
+  - schema
+  - type-compat
+tags: [shadow]

--- a/tests/tooling/assert-type-compat.mjs
+++ b/tests/tooling/assert-type-compat.mjs
@@ -518,6 +518,24 @@ export default function assertTypeCompat(doc) {
           }
         }
       }
+      if (node.$type === 'shadow' && node.$value && typeof node.$value === 'object') {
+        const checkShadowDimension = (dimension, prop) => {
+          if (!dimension || typeof dimension !== 'object' || Array.isArray(dimension)) {
+            return;
+          }
+          if (dimension.dimensionType !== 'length') {
+            errors.push({
+              code: 'E_SHADOW_DIMENSION_TYPE',
+              path: `${path}/$value/${prop}/dimensionType`,
+              message: `${prop} dimensionType must be "length"`
+            });
+          }
+        };
+        checkShadowDimension(node.$value.offsetX, 'offsetX');
+        checkShadowDimension(node.$value.offsetY, 'offsetY');
+        checkShadowDimension(node.$value.blur, 'blur');
+        checkShadowDimension(node.$value.spread, 'spread');
+      }
       if (node.$type === 'fontFace' && node.$value && typeof node.$value === 'object') {
         const fw = node.$value.fontWeight;
         if (typeof fw === 'string' && !isValidFontWeightString(fw)) {


### PR DESCRIPTION
## Summary
- update the core schema so shadow offsets, blur, and spread use the length-dimension definition
- extend the type compatibility tooling to flag non-length shadow dimensions
- add a regression fixture for shadows with invalid dimension types

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd105481508328a6ec9183dd10fc81