### PR TITLE
Allow border width keywords

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -798,8 +798,14 @@
           "$comment": "MUST identify CSS border/outline contexts or native stroke APIs such as CALayer and GradientDrawable."
         },
         "width": {
-          "$ref": "#/$defs/dimension",
-          "$comment": "Width MUST follow the <line-width> grammar and respect point/density conversions for pt, dp, and sp units."
+          "oneOf": [
+            { "$ref": "#/$defs/dimension" },
+            {
+              "type": "string",
+              "enum": ["thin", "medium", "thick"]
+            }
+          ],
+          "$comment": "Width MUST follow the <line-width> grammar, accepting CSS keywords or dimension values that respect point/density conversions for pt, dp, and sp units."
         },
         "style": {
           "type": "string",

--- a/tests/fixtures/negative/border-width-invalid-keyword/expected.error.json
+++ b/tests/fixtures/negative/border-width-invalid-keyword/expected.error.json
@@ -1,0 +1,1 @@
+{ "error": "Schema validation error: must match exactly one schema in oneOf" }

--- a/tests/fixtures/negative/border-width-invalid-keyword/input.json
+++ b/tests/fixtures/negative/border-width-invalid-keyword/input.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "border": {
+    "invalidKeyword": {
+      "$type": "border",
+      "$value": {
+        "borderType": "css.border",
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0.2, 0.2, 0.2, 1.0]
+        },
+        "style": "solid",
+        "width": "wide"
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/border-width-invalid-keyword/meta.yaml
+++ b/tests/fixtures/negative/border-width-invalid-keyword/meta.yaml
@@ -1,0 +1,5 @@
+name: border-width-invalid-keyword
+description: border width keywords must match CSS <line-width> options
+assertions:
+  - schema
+tags: [border]

--- a/tests/fixtures/positive/border/expected.json
+++ b/tests/fixtures/positive/border/expected.json
@@ -35,5 +35,17 @@
         "unit": "pt"
       }
     }
+  },
+  "keyword": {
+    "$type": "border",
+    "$value": {
+      "borderType": "css.border",
+      "color": {
+        "colorSpace": "srgb",
+        "components": [0.2, 0.2, 0.2, 1.0]
+      },
+      "style": "solid",
+      "width": "thin"
+    }
   }
 }

--- a/tests/fixtures/positive/border/input.json
+++ b/tests/fixtures/positive/border/input.json
@@ -36,5 +36,17 @@
         "unit": "pt"
       }
     }
+  },
+  "keyword": {
+    "$type": "border",
+    "$value": {
+      "borderType": "css.border",
+      "color": {
+        "colorSpace": "srgb",
+        "components": [0.2, 0.2, 0.2, 1.0]
+      },
+      "style": "solid",
+      "width": "thin"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow border tokens to specify widths using either dimensions or the thin/medium/thick keywords
- extend the positive border fixture with a keyword-width example
- add a negative fixture that rejects unsupported border width keywords

## Testing
- npm test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cd124147748328b6b3c0af08f2821b