### PR TITLE
Enforce valid fontStyle grammar

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -543,6 +543,11 @@
       "pattern": "^(?:[Bb][Oo][Ll][Dd][Ee][Rr]|[Ll][Ii][Gg][Hh][Tt][Ee][Rr]|(?:[Nn][Oo][Rr][Mm][Aa][Ll]|[Bb][Oo][Ll][Dd]|\\+?(?:0*(?:[1-9]\\d{0,2})(?:\\.\\d+)?|0*1000(?:\\.0+)?))(?:\\s+(?:[Nn][Oo][Rr][Mm][Aa][Ll]|[Bb][Oo][Ll][Dd]|\\+?(?:0*(?:[1-9]\\d{0,2})(?:\\.\\d+)?|0*1000(?:\\.0+)?)))?)$",
       "$comment": "String weights MUST conform to CSS <font-weight-absolute>, <font-weight-relative>, or <font-weight-range> productions (css-fonts-4)."
     },
+    "font-style-string": {
+      "type": "string",
+      "pattern": "^(?:[Nn][Oo][Rr][Mm][Aa][Ll]|[Ii][Tt][Aa][Ll][Ii][Cc]|[Oo][Bb][Ll][Ii][Qq][Uu][Ee](?:\\s+[-+]?(?:\\d+(?:\\.\\d+)?|\\.\\d+)(?:[Ee][+-]?\\d+)?(?:[Dd][Ee][Gg]|[Gg][Rr][Aa][Dd]|[Rr][Aa][Dd]|[Tt][Uu][Rr][Nn]))?)$",
+      "$comment": "Font style keywords MUST match CSS font-style grammar, optionally supplying an oblique angle (css-fonts-4, css-values-4)."
+    },
     "font": {
       "type": "object",
       "required": ["fontType", "family"],
@@ -643,7 +648,7 @@
           ]
         },
         "fontStyle": {
-          "type": "string",
+          "$ref": "#/$defs/font-style-string",
           "$comment": "MUST conform to CSS font-style descriptor grammar (css-fonts-4); oblique angles map to the slnt variation axis per UIFontDescriptor.AttributeName.variations and Typeface.Builder#setFontVariationSettings (IOS-FONT-VARIATIONS, ANDROID-FONT-VARIATION)."
         },
         "fontStretch": {
@@ -729,7 +734,7 @@
           ]
         },
         "fontStyle": {
-          "type": "string",
+          "$ref": "#/$defs/font-style-string",
           "$comment": "MUST conform to CSS font-style grammar and map to native italic traits or the slnt variation axis (css-fonts-4, IOS-FONT-TRAITS, IOS-FONT-VARIATIONS, ANDROID-FONT-SLANT, ANDROID-FONT-VARIATION)."
         },
         "fontVariant": {

--- a/tests/fixtures/negative/font-face-invalid-style/expected.error.json
+++ b/tests/fixtures/negative/font-face-invalid-style/expected.error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "E_INVALID_KEYWORD",
+    "path": "/fontFace/bad/$value/fontStyle",
+    "message": "invalid keyword"
+  }
+}

--- a/tests/fixtures/negative/font-face-invalid-style/input.json
+++ b/tests/fixtures/negative/font-face-invalid-style/input.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "fontFace": {
+    "bad": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Example Sans",
+        "src": [{ "local": "Example Sans" }],
+        "fontStyle": "lean"
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/font-face-invalid-style/meta.yaml
+++ b/tests/fixtures/negative/font-face-invalid-style/meta.yaml
@@ -1,0 +1,6 @@
+name: font-face-invalid-style
+description: fontFace tokens reject invalid fontStyle keywords
+assertions:
+  - type-compat
+tags:
+  - fontFace

--- a/tests/fixtures/positive/font-face-oblique-style/expected.json
+++ b/tests/fixtures/positive/font-face-oblique-style/expected.json
@@ -1,0 +1,26 @@
+{
+  "fontFace": {
+    "oblique": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Example Sans",
+        "src": [{ "local": "Example Sans" }],
+        "fontStyle": "oblique 14deg"
+      }
+    }
+  },
+  "typography": {
+    "slanted": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Example Sans",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 1.125,
+          "unit": "rem"
+        },
+        "fontStyle": "oblique -0.25turn"
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/font-face-oblique-style/input.json
+++ b/tests/fixtures/positive/font-face-oblique-style/input.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "fontFace": {
+    "oblique": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Example Sans",
+        "src": [{ "local": "Example Sans" }],
+        "fontStyle": "oblique 14deg"
+      }
+    }
+  },
+  "typography": {
+    "slanted": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Example Sans",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 1.125,
+          "unit": "rem"
+        },
+        "fontStyle": "oblique -0.25turn"
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/font-face-oblique-style/meta.yaml
+++ b/tests/fixtures/positive/font-face-oblique-style/meta.yaml
@@ -1,0 +1,9 @@
+name: font-face-oblique-style
+description: fontFace and typography tokens accept oblique fontStyle angles
+assertions:
+  - schema
+  - type-compat
+  - roundtrip
+tags:
+  - fontFace
+  - typography

--- a/tests/tooling/assert-type-compat.mjs
+++ b/tests/tooling/assert-type-compat.mjs
@@ -67,6 +67,8 @@ const FONT_WEIGHT_ABSOLUTE_KEYWORDS = new Map([
 ]);
 const FONT_WEIGHT_RELATIVE_KEYWORDS = new Set(['bolder', 'lighter']);
 const FONT_WEIGHT_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
+const FONT_STYLE_PATTERN =
+  /^(?:normal|italic|oblique(?:\s+[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?(?:deg|grad|rad|turn))?)$/i;
 
 function parseFontWeightAbsoluteValue(token) {
   if (typeof token !== 'string') {
@@ -110,6 +112,17 @@ function isValidFontWeightString(value) {
     }
   }
   return false;
+}
+
+function isValidFontStyle(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    return false;
+  }
+  return FONT_STYLE_PATTERN.test(normalized);
 }
 
 function getMotionCategory(motionType) {
@@ -537,6 +550,14 @@ export default function assertTypeCompat(doc) {
         checkShadowDimension(node.$value.spread, 'spread');
       }
       if (node.$type === 'fontFace' && node.$value && typeof node.$value === 'object') {
+        const fs = node.$value.fontStyle;
+        if (typeof fs === 'string' && !isValidFontStyle(fs)) {
+          errors.push({
+            code: 'E_INVALID_KEYWORD',
+            path: `${path}/$value/fontStyle`,
+            message: 'invalid keyword'
+          });
+        }
         const fw = node.$value.fontWeight;
         if (typeof fw === 'string' && !isValidFontWeightString(fw)) {
           errors.push({
@@ -589,6 +610,14 @@ export default function assertTypeCompat(doc) {
           errors.push({
             code: 'E_INVALID_KEYWORD',
             path: `${path}/$value/fontWeight`,
+            message: 'invalid keyword'
+          });
+        }
+        const fs = node.$value.fontStyle;
+        if (typeof fs === 'string' && !isValidFontStyle(fs)) {
+          errors.push({
+            code: 'E_INVALID_KEYWORD',
+            path: `${path}/$value/fontStyle`,
             message: 'invalid keyword'
           });
         }


### PR DESCRIPTION
## Summary
- add a reusable `font-style-string` helper and require `fontFace`/`typography` fontStyle values to match CSS keywords with optional oblique angles
- extend the type compatibility assertions to reject invalid fontStyle keywords for fontFace and typography tokens
- cover the validation with new positive and negative fixtures for oblique angles and invalid keywords

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cd13ba65688328a850345f8584a0b6