### PR TITLE
Validate typography font feature tags

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -759,7 +759,8 @@
           "$comment": "MUST contain OpenType feature tags per CSS font-feature-settings and the OpenType registry.",
           "items": {
             "type": "string",
-            "$comment": "MUST be a registered OpenType feature tag or a documented font-specific tag."
+            "pattern": "^[A-Za-z0-9]{4}$",
+            "$comment": "MUST be a four-character OpenType feature tag registered by CSS font-feature-settings or documented by the font."
           }
         },
         "underlineThickness": { "$ref": "#/$defs/font-dimension" },

--- a/tests/fixtures/negative/font-features-invalid-tag/expected.error.json
+++ b/tests/fixtures/negative/font-features-invalid-tag/expected.error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "E_INVALID_KEYWORD",
+    "path": "/typography/bad/$value/fontFeatures/1",
+    "message": "invalid keyword"
+  }
+}

--- a/tests/fixtures/negative/font-features-invalid-tag/input.json
+++ b/tests/fixtures/negative/font-features-invalid-tag/input.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "typography": {
+    "bad": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
+        "fontFeatures": ["liga", ""]
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/font-features-invalid-tag/meta.yaml
+++ b/tests/fixtures/negative/font-features-invalid-tag/meta.yaml
@@ -1,0 +1,5 @@
+name: font-features-invalid-tag
+description: typography token fontFeatures entry with invalid OpenType tag
+assertions:
+  - type-compat
+tags: [typography]

--- a/tests/fixtures/positive/typography-font-features/expected.json
+++ b/tests/fixtures/positive/typography-font-features/expected.json
@@ -1,0 +1,13 @@
+{
+  "typography": {
+    "features": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Inter",
+        "fontFeatures": ["cv01", "liga"],
+        "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
+        "typographyType": "body"
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/typography-font-features/input.json
+++ b/tests/fixtures/positive/typography-font-features/input.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "typography": {
+    "features": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Inter",
+        "fontFeatures": ["cv01", "liga"],
+        "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
+        "typographyType": "body"
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/typography-font-features/meta.yaml
+++ b/tests/fixtures/positive/typography-font-features/meta.yaml
@@ -1,0 +1,7 @@
+name: typography-font-features
+description: typography token with valid OpenType feature tags
+assertions:
+  - schema
+  - type-compat
+  - refs
+tags: [typography]

--- a/tests/tooling/assert-type-compat.mjs
+++ b/tests/tooling/assert-type-compat.mjs
@@ -69,6 +69,7 @@ const FONT_WEIGHT_RELATIVE_KEYWORDS = new Set(['bolder', 'lighter']);
 const FONT_WEIGHT_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
 const FONT_STYLE_PATTERN =
   /^(?:normal|italic|oblique(?:\s+[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?(?:deg|grad|rad|turn))?)$/i;
+const FONT_FEATURE_TAG_PATTERN = /^[A-Za-z0-9]{4}$/;
 
 function parseFontWeightAbsoluteValue(token) {
   if (typeof token !== 'string') {
@@ -611,6 +612,18 @@ export default function assertTypeCompat(doc) {
             code: 'E_INVALID_KEYWORD',
             path: `${path}/$value/fontWeight`,
             message: 'invalid keyword'
+          });
+        }
+        const fontFeatures = node.$value.fontFeatures;
+        if (Array.isArray(fontFeatures)) {
+          fontFeatures.forEach((feature, idx) => {
+            if (typeof feature === 'string' && !FONT_FEATURE_TAG_PATTERN.test(feature)) {
+              errors.push({
+                code: 'E_INVALID_KEYWORD',
+                path: `${path}/$value/fontFeatures/${idx}`,
+                message: 'invalid keyword'
+              });
+            }
           });
         }
         const fs = node.$value.fontStyle;


### PR DESCRIPTION
## Summary
- require typography fontFeatures entries to match four-character OpenType feature tags in the core schema
- teach the type-compat tooling to flag invalid typography fontFeatures and cover the behaviour with fixtures

## Testing
- npm run format
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd15350b8483288041ac2f5f9a5aff