### PR TITLE
Tighten font style validation for font tokens

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -562,8 +562,7 @@
           "$comment": "MUST identify a family using CSS <family-name> grammar (css-fonts-4) or platform catalog registrations (IOS-FONT-CATALOG, ANDROID-FONT-FAMILY)."
         },
         "style": {
-          "type": "string",
-          "pattern": "^(?:[A-Za-z][A-Za-z0-9-]*)(?:\\s+-?(?:\\d+(?:\\.\\d+)?)(?:deg|grad|rad|turn)?)?$",
+          "$ref": "#/$defs/font-style-string",
           "$comment": "MUST conform to CSS <font-style-absolute> grammar (css-fonts-4); angles MUST follow <angle> (css-values-4)."
         },
         "weight": {

--- a/tests/fixtures/negative/font-invalid-style/expected.error.json
+++ b/tests/fixtures/negative/font-invalid-style/expected.error.json
@@ -1,0 +1,1 @@
+{ "error": "Schema validation error: font style must be normal, italic, or oblique" }

--- a/tests/fixtures/negative/font-invalid-style/input.json
+++ b/tests/fixtures/negative/font-invalid-style/input.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "font": {
+    "bad": {
+      "$type": "font",
+      "$value": {
+        "fontType": "css.font-face",
+        "family": "Example Sans",
+        "style": "italic 10deg"
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/font-invalid-style/meta.yaml
+++ b/tests/fixtures/negative/font-invalid-style/meta.yaml
@@ -1,0 +1,6 @@
+name: font-invalid-style
+description: font tokens reject invalid font style keywords
+assertions:
+  - schema
+tags:
+  - type:font


### PR DESCRIPTION
## Summary
- reuse the shared font-style definition in the font schema so only normal, italic, or oblique styles (with optional angles) are accepted
- add a negative fixture that covers an invalid italic style string

## Testing
- node tests/tooling/run.mjs
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cd217e4ba08328afae4c0a149ff447