### PR TITLE
Validate fontStretch grammar

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -548,6 +548,11 @@
       "pattern": "^(?:[Nn][Oo][Rr][Mm][Aa][Ll]|[Ii][Tt][Aa][Ll][Ii][Cc]|[Oo][Bb][Ll][Ii][Qq][Uu][Ee](?:\\s+[-+]?(?:\\d+(?:\\.\\d+)?|\\.\\d+)(?:[Ee][+-]?\\d+)?(?:[Dd][Ee][Gg]|[Gg][Rr][Aa][Dd]|[Rr][Aa][Dd]|[Tt][Uu][Rr][Nn]))?)$",
       "$comment": "Font style keywords MUST match CSS font-style grammar, optionally supplying an oblique angle (css-fonts-4, css-values-4)."
     },
+    "font-stretch-string": {
+      "type": "string",
+      "pattern": "^(?:[Nn][Oo][Rr][Mm][Aa][Ll]|(?:[Uu][Ll][Tt][Rr][Aa]|[Ee][Xx][Tt][Rr][Aa]|[Ss][Ee][Mm][Ii])-[Cc][Oo][Nn][Dd][Ee][Nn][Ss][Ee][Dd]|[Cc][Oo][Nn][Dd][Ee][Nn][Ss][Ee][Dd]|(?:[Ss][Ee][Mm][Ii]|[Ee][Xx][Tt][Rr][Aa]|[Uu][Ll][Tt][Rr][Aa])-[Ee][Xx][Pp][Aa][Nn][Dd][Ee][Dd]|[Ee][Xx][Pp][Aa][Nn][Dd][Ee][Dd]|\\+?(?:0*(?:[1-9]\\d{0,2})(?:\\.\\d+)?|0*1000(?:\\.0+)?)%)$",
+      "$comment": "Font stretch values MUST match CSS <font-stretch-absolute> grammar (css-fonts-4)."
+    },
     "font": {
       "type": "object",
       "required": ["fontType", "family"],
@@ -651,7 +656,7 @@
           "$comment": "MUST conform to CSS font-style descriptor grammar (css-fonts-4); oblique angles map to the slnt variation axis per UIFontDescriptor.AttributeName.variations and Typeface.Builder#setFontVariationSettings (IOS-FONT-VARIATIONS, ANDROID-FONT-VARIATION)."
         },
         "fontStretch": {
-          "type": "string",
+          "$ref": "#/$defs/font-stretch-string",
           "$comment": "Stretch keywords MUST follow CSS <font-stretch-absolute> grammar (css-fonts-4)."
         },
         "unicodeRange": {
@@ -741,7 +746,7 @@
           "$comment": "MUST match the CSS font-variant grammar when present."
         },
         "fontStretch": {
-          "type": "string",
+          "$ref": "#/$defs/font-stretch-string",
           "$comment": "MUST match the CSS font-stretch grammar when present."
         },
         "textDecoration": {

--- a/tests/fixtures/negative/font-face-invalid-stretch/expected.error.json
+++ b/tests/fixtures/negative/font-face-invalid-stretch/expected.error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "E_INVALID_KEYWORD",
+    "path": "/fontFace/bad/$value/fontStretch",
+    "message": "invalid keyword"
+  }
+}

--- a/tests/fixtures/negative/font-face-invalid-stretch/input.json
+++ b/tests/fixtures/negative/font-face-invalid-stretch/input.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "fontFace": {
+    "bad": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Example Sans",
+        "src": [{ "local": "Example Sans" }],
+        "fontStretch": "squished"
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/font-face-invalid-stretch/meta.yaml
+++ b/tests/fixtures/negative/font-face-invalid-stretch/meta.yaml
@@ -1,0 +1,6 @@
+name: font-face-invalid-stretch
+description: fontFace tokens reject invalid fontStretch keywords
+assertions:
+  - type-compat
+tags:
+  - fontFace

--- a/tests/fixtures/positive/font-stretch-percentage/expected.json
+++ b/tests/fixtures/positive/font-stretch-percentage/expected.json
@@ -1,0 +1,22 @@
+{
+  "fontFace": {
+    "wide": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Wide Sans",
+        "fontStretch": "112.5%",
+        "src": [{ "local": "Wide Sans" }]
+      }
+    }
+  },
+  "typography": {
+    "display": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Wide Sans",
+        "fontSize": { "dimensionType": "length", "value": 48, "unit": "px" },
+        "fontStretch": "112.5%"
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/font-stretch-percentage/input.json
+++ b/tests/fixtures/positive/font-stretch-percentage/input.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "fontFace": {
+    "wide": {
+      "$type": "fontFace",
+      "$value": {
+        "fontFamily": "Wide Sans",
+        "fontStretch": "112.5%",
+        "src": [{ "local": "Wide Sans" }]
+      }
+    }
+  },
+  "typography": {
+    "display": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Wide Sans",
+        "fontSize": { "dimensionType": "length", "value": 48, "unit": "px" },
+        "fontStretch": "112.5%"
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/font-stretch-percentage/meta.yaml
+++ b/tests/fixtures/positive/font-stretch-percentage/meta.yaml
@@ -1,0 +1,10 @@
+name: font-stretch-percentage
+description: fontStretch accepts percentage values in fontFace and typography tokens
+assertions:
+  - schema
+  - type-compat
+  - ordering
+  - roundtrip
+tags:
+  - fontFace
+  - typography

--- a/tests/tooling/assert-type-compat.mjs
+++ b/tests/tooling/assert-type-compat.mjs
@@ -69,6 +69,8 @@ const FONT_WEIGHT_RELATIVE_KEYWORDS = new Set(['bolder', 'lighter']);
 const FONT_WEIGHT_NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/;
 const FONT_STYLE_PATTERN =
   /^(?:normal|italic|oblique(?:\s+[-+]?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?(?:deg|grad|rad|turn))?)$/i;
+const FONT_STRETCH_PATTERN =
+  /^(?:normal|ultra-condensed|extra-condensed|condensed|semi-condensed|semi-expanded|expanded|extra-expanded|ultra-expanded|\+?(?:0*(?:[1-9]\d{0,2})(?:\.\d+)?|0*1000(?:\.0+)?)%)$/i;
 const FONT_FEATURE_TAG_PATTERN = /^[A-Za-z0-9]{4}$/;
 
 function parseFontWeightAbsoluteValue(token) {
@@ -124,6 +126,17 @@ function isValidFontStyle(value) {
     return false;
   }
   return FONT_STYLE_PATTERN.test(normalized);
+}
+
+function isValidFontStretch(value) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    return false;
+  }
+  return FONT_STRETCH_PATTERN.test(normalized);
 }
 
 function getMotionCategory(motionType) {
@@ -567,6 +580,14 @@ export default function assertTypeCompat(doc) {
             message: 'invalid keyword'
           });
         }
+        const fst = node.$value.fontStretch;
+        if (typeof fst === 'string' && !isValidFontStretch(fst)) {
+          errors.push({
+            code: 'E_INVALID_KEYWORD',
+            path: `${path}/$value/fontStretch`,
+            message: 'invalid keyword'
+          });
+        }
       }
       if (node.$type === 'typography' && node.$value && typeof node.$value === 'object') {
         const fontSize = node.$value.fontSize;
@@ -605,6 +626,14 @@ export default function assertTypeCompat(doc) {
               message: 'wordSpacing dimensionType must be "length"'
             });
           }
+        }
+        const fontStretch = node.$value.fontStretch;
+        if (typeof fontStretch === 'string' && !isValidFontStretch(fontStretch)) {
+          errors.push({
+            code: 'E_INVALID_KEYWORD',
+            path: `${path}/$value/fontStretch`,
+            message: 'invalid keyword'
+          });
         }
         const fw = node.$value.fontWeight;
         if (typeof fw === 'string' && !isValidFontWeightString(fw)) {


### PR DESCRIPTION
## Summary
- add a shared `font-stretch-string` schema definition and reuse it for `fontFace` and `typography` token validation
- tighten type-compatibility checks to reject `fontStretch` values outside the CSS grammar
- cover the stricter grammar with new negative and percentage fixtures

## Testing
- node tests/tooling/run.mjs
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cd22cfa43483288eac0649cd9d3f8a