### PR TITLE
Allow dashed CSS identifiers for color spaces

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -32,6 +32,11 @@
         }
       ]
     },
+    "css-ident": {
+      "type": "string",
+      "pattern": "^-{0,2}[A-Za-z_][A-Za-z0-9_-]*$",
+      "$comment": "MUST conform to CSS <ident> / <dashed-ident> productions (css-values-4)."
+    },
     "override": {
       "type": "object",
       "properties": {
@@ -493,8 +498,7 @@
       "required": ["colorSpace", "components"],
       "properties": {
         "colorSpace": {
-          "type": "string",
-          "pattern": "^[A-Za-z][A-Za-z0-9-]*$",
+          "$ref": "#/$defs/css-ident",
           "$comment": "MUST be a CSS <ident> naming a colour space defined by CSS Color 4 or registered via @color-profile (css-color-4)."
         },
         "components": {

--- a/tests/fixtures/negative/color-invalid-ident/expected.error.json
+++ b/tests/fixtures/negative/color-invalid-ident/expected.error.json
@@ -1,0 +1,3 @@
+{
+  "error": "must match pattern \"^-{0,2}[A-Za-z_][A-Za-z0-9_-]*$\""
+}

--- a/tests/fixtures/negative/color-invalid-ident/input.json
+++ b/tests/fixtures/negative/color-invalid-ident/input.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "color": {
+    "invalid": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "1foo",
+        "components": [1, 0, 0]
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/color-invalid-ident/meta.yaml
+++ b/tests/fixtures/negative/color-invalid-ident/meta.yaml
@@ -1,0 +1,4 @@
+name: color invalid ident
+description: rejects color spaces that are not CSS identifiers
+assertions:
+  - schema

--- a/tests/fixtures/positive/color/dashed-ident/expected.json
+++ b/tests/fixtures/positive/color/dashed-ident/expected.json
@@ -1,0 +1,11 @@
+{
+  "color": {
+    "brand": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "--brand-primary",
+        "components": [0.12, 0.34, 0.56]
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/color/dashed-ident/input.json
+++ b/tests/fixtures/positive/color/dashed-ident/input.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "color": {
+    "brand": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "--brand-primary",
+        "components": [0.12, 0.34, 0.56]
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/color/dashed-ident/meta.yaml
+++ b/tests/fixtures/positive/color/dashed-ident/meta.yaml
@@ -1,0 +1,11 @@
+name: color dashed ident
+description: accepts CSS dashed-ident names for color spaces
+assertions:
+  - schema
+  - refs
+  - type-compat
+  - roundtrip
+  - ordering
+tags:
+  - type:color
+  - color-space


### PR DESCRIPTION
## Summary
- add a reusable css-ident definition and update color tokens to consume it
- cover dashed and invalid colorSpace identifiers with new fixtures

## Testing
- npm test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cd28713cd48328a87f30ea7f58637a