### PR TITLE
Enforce elevation length dimensions

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -1403,11 +1403,11 @@
           "$comment": "MUST identify the rendering context defined by CSS <shadow> functions, UIKit CALayer/NSShadow properties, or Android elevation/shadow APIs (for example css.box-shadow.surface, ios.layer.surface, android.paint.shadow-layer.surface)."
         },
         "offset": {
-          "$ref": "#/$defs/dimension",
+          "$ref": "#/$defs/length-dimension",
           "$comment": "Vertical offset MUST conform to CSS <length> grammar and map to CALayer.shadowOffset.height, Paint#setShadowLayer dy, or View#setElevation displacement."
         },
         "blur": {
-          "$ref": "#/$defs/dimension",
+          "$ref": "#/$defs/length-dimension",
           "$comment": "Blur radius MUST match the <length> position in CSS <shadow> and the CALayer.shadowRadius / Paint#setShadowLayer radius semantics."
         },
         "color": {

--- a/tests/fixtures/negative/elevation-invalid-dimension-type/expected.error.json
+++ b/tests/fixtures/negative/elevation-invalid-dimension-type/expected.error.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "E_ELEVATION_DIMENSION_TYPE",
+    "path": "/elevation/bad/$value/offset/dimensionType",
+    "message": "offset dimensionType must be \"length\""
+  }
+}

--- a/tests/fixtures/negative/elevation-invalid-dimension-type/input.json
+++ b/tests/fixtures/negative/elevation-invalid-dimension-type/input.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "elevation": {
+    "bad": {
+      "$type": "elevation",
+      "$value": {
+        "elevationType": "css.box-shadow.surface",
+        "offset": { "dimensionType": "angle", "value": 8, "unit": "deg" },
+        "blur": { "dimensionType": "length", "value": 24, "unit": "px" },
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0.059, 0.09, 0.165, 0.18]
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/elevation-invalid-dimension-type/meta.yaml
+++ b/tests/fixtures/negative/elevation-invalid-dimension-type/meta.yaml
@@ -1,0 +1,6 @@
+name: elevation-invalid-dimension-type
+description: elevation offset and blur must use length dimensions
+assertions:
+  - schema
+  - type-compat
+tags: [elevation]

--- a/tests/tooling/assert-type-compat.mjs
+++ b/tests/tooling/assert-type-compat.mjs
@@ -563,6 +563,28 @@ export default function assertTypeCompat(doc) {
         checkShadowDimension(node.$value.blur, 'blur');
         checkShadowDimension(node.$value.spread, 'spread');
       }
+      if (node.$type === 'elevation' && node.$value && typeof node.$value === 'object') {
+        const checkElevationDimension = (dimension, prop) => {
+          const basePath = `${path}/$value/${prop}`;
+          if (!dimension || typeof dimension !== 'object' || Array.isArray(dimension)) {
+            errors.push({
+              code: 'E_ELEVATION_DIMENSION_TYPE',
+              path: basePath,
+              message: `${prop} must be a length dimension object`
+            });
+            return;
+          }
+          if (dimension.dimensionType !== 'length') {
+            errors.push({
+              code: 'E_ELEVATION_DIMENSION_TYPE',
+              path: `${basePath}/dimensionType`,
+              message: `${prop} dimensionType must be "length"`
+            });
+          }
+        };
+        checkElevationDimension(node.$value.offset, 'offset');
+        checkElevationDimension(node.$value.blur, 'blur');
+      }
       if (node.$type === 'fontFace' && node.$value && typeof node.$value === 'object') {
         const fs = node.$value.fontStyle;
         if (typeof fs === 'string' && !isValidFontStyle(fs)) {


### PR DESCRIPTION
## Summary
- ensure the elevation schema points offset and blur at the length dimension definition
- extend the type compatibility checks to require length dimensions on elevation offset and blur
- add a negative fixture covering an elevation token with an invalid offset dimension type

## Testing
- npm test
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cd2a0957608328a0c61d4d7de553d4