### PR TITLE
Restrict typography letter-spacing keyword

### DIFF
--- a/schema/core.json
+++ b/schema/core.json
@@ -715,6 +715,7 @@
             { "$ref": "#/$defs/font-dimension" },
             {
               "type": "string",
+              "enum": ["normal"],
               "$comment": "MUST be the keyword 'normal' per CSS Text Module Level 3 letter-spacing grammar."
             }
           ]

--- a/tests/fixtures/negative/letter-spacing-invalid-keyword/expected.error.json
+++ b/tests/fixtures/negative/letter-spacing-invalid-keyword/expected.error.json
@@ -1,0 +1,5 @@
+{
+  "error": {
+    "message": "must be equal to one of the allowed values"
+  }
+}

--- a/tests/fixtures/negative/letter-spacing-invalid-keyword/input.json
+++ b/tests/fixtures/negative/letter-spacing-invalid-keyword/input.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "typography": {
+    "invalidKeyword": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 16,
+          "unit": "px"
+        },
+        "letterSpacing": "loose"
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/letter-spacing-invalid-keyword/meta.yaml
+++ b/tests/fixtures/negative/letter-spacing-invalid-keyword/meta.yaml
@@ -1,0 +1,5 @@
+name: letter-spacing-invalid-keyword
+description: letterSpacing keyword must be the literal normal value
+assertions:
+  - schema
+tags: [typography]

--- a/tests/fixtures/positive/letter-spacing-normal-literal/expected.json
+++ b/tests/fixtures/positive/letter-spacing-normal-literal/expected.json
@@ -1,0 +1,17 @@
+{
+  "typography": {
+    "normalLiteral": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 16,
+          "unit": "px"
+        },
+        "letterSpacing": "normal"
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/letter-spacing-normal-literal/input.json
+++ b/tests/fixtures/positive/letter-spacing-normal-literal/input.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "typography": {
+    "normalLiteral": {
+      "$type": "typography",
+      "$value": {
+        "typographyType": "body",
+        "fontFamily": "Inter",
+        "fontSize": {
+          "dimensionType": "length",
+          "value": 16,
+          "unit": "px"
+        },
+        "letterSpacing": "normal"
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/letter-spacing-normal-literal/meta.yaml
+++ b/tests/fixtures/positive/letter-spacing-normal-literal/meta.yaml
@@ -1,0 +1,7 @@
+name: letter-spacing-normal-literal
+description: typography token with literal keyword letterSpacing
+assertions:
+  - schema
+  - type-compat
+  - refs
+tags: [typography]


### PR DESCRIPTION
## Summary
- restrict the typography `letterSpacing` string branch to the literal `normal` keyword
- add fixtures covering a valid `normal` literal and an invalid `loose` keyword

## Testing
- npm run format
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd2b72766083288d87c0ee6441b452