### PR TITLE
feat: add strokeStyle token support and fixtures

### DIFF
--- a/docs/examples/border.md
+++ b/docs/examples/border.md
@@ -5,7 +5,7 @@ description: Cross-platform border strokes with per-corner radii and style metad
 
 # Border tokens {#border}
 
-This example maps card and focus borders onto CSS outlines, UIKit layers, and Android drawables. It demonstrates dotted, dashed, and solid styles while keeping per-corner radii aligned across platforms.
+This example maps card and focus borders onto CSS outlines, UIKit layers, and Android drawables. It demonstrates dotted, dashed, and solid styles while keeping per-corner radii aligned across platforms, and reuses `strokeStyle` tokens to share dash metadata between borders.
 
 See [`border.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examples/border.tokens.json) for the complete document.
 
@@ -51,6 +51,51 @@ See [`border.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examples
         }
       }
     },
+    "cardOutlineIos": {
+      "$type": "border",
+      "$value": {
+        "borderType": "ios.layer",
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0.141, 0.286, 0.486, 1]
+        },
+        "radius": {
+          "bottomLeft": {
+            "x": {
+              "dimensionType": "length",
+              "value": 20,
+              "unit": "pt"
+            }
+          },
+          "topLeft": {
+            "x": {
+              "dimensionType": "length",
+              "value": 12,
+              "unit": "pt"
+            },
+            "y": {
+              "dimensionType": "length",
+              "value": 8,
+              "unit": "pt"
+            }
+          },
+          "topRight": {
+            "x": {
+              "dimensionType": "length",
+              "value": 20,
+              "unit": "pt"
+            }
+          }
+        },
+        "style": "dashed",
+        "strokeStyle": { "$ref": "#/strokeStyle/cardDashed" },
+        "width": {
+          "dimensionType": "length",
+          "value": 1.5,
+          "unit": "pt"
+        }
+      }
+    },
     "focusRing": {
       "$type": "border",
       "$value": {
@@ -65,11 +110,24 @@ See [`border.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examples
           "unit": "pt"
         },
         "style": "solid",
+        "strokeStyle": {
+          "lineCap": "round"
+        },
         "width": {
           "dimensionType": "length",
           "value": 2,
           "unit": "pt"
         }
+      }
+    }
+  },
+  "strokeStyle": {
+    "cardDashed": {
+      "$type": "strokeStyle",
+      "$value": {
+        "dashArray": [6, 3],
+        "lineCap": "round",
+        "lineJoin": "round"
       }
     }
   }

--- a/docs/guides/migrating-from-dtcg.md
+++ b/docs/guides/migrating-from-dtcg.md
@@ -512,6 +512,15 @@ richer schemas for these structures.
 ```json
 {
   "$version": "1.0.0",
+  "strokeStyle": {
+    "focus": {
+      "$type": "strokeStyle",
+      "$value": {
+        "dashArray": [4, 2],
+        "lineCap": "round"
+      }
+    }
+  },
   "border": {
     "focus-outline": {
       "$type": "border",
@@ -522,16 +531,11 @@ richer schemas for these structures.
           "components": [0.0, 0.435, 1.0, 1.0]
         },
         "style": "solid",
+        "strokeStyle": { "$ref": "#/strokeStyle/focus" },
         "width": {
           "dimensionType": "length",
           "value": 2,
           "unit": "px"
-        }
-      },
-      "$extensions": {
-        "org.example.stroke": {
-          "dashArray": [4, 2],
-          "lineCap": "round"
         }
       }
     }
@@ -539,8 +543,9 @@ richer schemas for these structures.
 }
 ```
 
-DTIF `border` tokens capture the rendering context through `borderType` and store
-platform-specific stroke details inside vendor extensions.
+DTIF `border` tokens capture the rendering context through `borderType`, reuse
+stroke metadata via a first-class `strokeStyle` token, and avoid vendor
+extensions for dash patterns.
 
 ### Shadows {#shadows}
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,9 +33,10 @@ metrics while exercising optional spread radii implemented via `shadowPath` and
 `border.tokens.json` demonstrates CSS `border` and `outline` shorthands alongside
 UIKit `CALayer` borders and Android `GradientDrawable#setStroke`. The fixture
 mixes `px`, `pt`, and `dp` widths, exercises `solid`, `dashed`, and `dotted`
-styles, and encodes per-corner radii using the `border-radius` grammar so teams
-can verify conversions to `CAShapeLayer.lineDashPattern` and
-`GradientDrawable#setCornerRadii` without copying keyword lists.
+styles, reuses dedicated `strokeStyle` tokens for dash patterns, and encodes
+per-corner radii using the `border-radius` grammar so teams can verify
+conversions to `CAShapeLayer.lineDashPattern` and `GradientDrawable#setCornerRadii`
+without copying keyword lists.
 
 ## Elevation layers
 

--- a/examples/border.tokens.json
+++ b/examples/border.tokens.json
@@ -75,6 +75,7 @@
           }
         },
         "style": "dashed",
+        "strokeStyle": { "$ref": "#/strokeStyle/cardDashed" },
         "width": {
           "dimensionType": "length",
           "value": 1.5,
@@ -96,11 +97,24 @@
           "unit": "pt"
         },
         "style": "solid",
+        "strokeStyle": {
+          "lineCap": "round"
+        },
         "width": {
           "dimensionType": "length",
           "value": 2,
           "unit": "pt"
         }
+      }
+    }
+  },
+  "strokeStyle": {
+    "cardDashed": {
+      "$type": "strokeStyle",
+      "$value": {
+        "dashArray": [6, 3],
+        "lineCap": "round",
+        "lineJoin": "round"
       }
     }
   }

--- a/examples/complete.tokens.json
+++ b/examples/complete.tokens.json
@@ -66,6 +66,7 @@
           "unit": "pt"
         },
         "style": "solid",
+        "strokeStyle": { "$ref": "#/strokeStyle/focusRing" },
         "width": {
           "dimensionType": "length",
           "value": 2,
@@ -122,6 +123,7 @@
           }
         },
         "style": "dashed",
+        "strokeStyle": { "$ref": "#/strokeStyle/iosCard" },
         "width": {
           "dimensionType": "length",
           "value": 1.5,
@@ -1258,6 +1260,22 @@
       "$author": "Designer",
       "$tags": ["shadow", "inner"],
       "$hash": "33aa04418deebfbd8e0574e638607ce63a4df8a3ea00bafbb4f9751b7c34d3f7"
+    }
+  },
+  "strokeStyle": {
+    "focusRing": {
+      "$type": "strokeStyle",
+      "$value": {
+        "lineCap": "round"
+      }
+    },
+    "iosCard": {
+      "$type": "strokeStyle",
+      "$value": {
+        "dashArray": [6, 3],
+        "lineCap": "round",
+        "lineJoin": "round"
+      }
     }
   },
   "themes": {

--- a/examples/dtcg-migration/border.tokens.json
+++ b/examples/dtcg-migration/border.tokens.json
@@ -10,17 +10,21 @@
           "components": [0.0, 0.435, 1.0, 1.0]
         },
         "style": "solid",
+        "strokeStyle": { "$ref": "#/strokeStyle/focus" },
         "width": {
           "dimensionType": "length",
           "value": 2,
           "unit": "px"
         }
-      },
-      "$extensions": {
-        "org.example.stroke": {
-          "dashArray": [4, 2],
-          "lineCap": "round"
-        }
+      }
+    }
+  },
+  "strokeStyle": {
+    "focus": {
+      "$type": "strokeStyle",
+      "$value": {
+        "dashArray": [4, 2],
+        "lineCap": "round"
       }
     }
   }

--- a/registry/types.json
+++ b/registry/types.json
@@ -95,6 +95,12 @@
     "contact": "https://github.com/bylapidist/dtif",
     "spec": "https://github.com/bylapidist/dtif/blob/main/docs/spec/token-types.md#shadow-tokens"
   },
+  "strokeStyle": {
+    "vendor": "net.lapidist.dtif",
+    "owner": "Lapidist",
+    "contact": "https://github.com/bylapidist/dtif",
+    "spec": "https://github.com/bylapidist/dtif/blob/main/docs/spec/token-types.md#stroke-style-tokens"
+  },
   "typography": {
     "vendor": "net.lapidist.dtif",
     "owner": "Lapidist",

--- a/schema/core.json
+++ b/schema/core.json
@@ -229,6 +229,16 @@
           }
         },
         {
+          "if": { "properties": { "$type": { "const": "strokeStyle" } }, "required": ["$type"] },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [{ "$ref": "#/$defs/strokeStyle" }, { "$ref": "#/$defs/function" }]
+              }
+            }
+          }
+        },
+        {
           "if": { "properties": { "$type": { "const": "cursor" } }, "required": ["$type"] },
           "then": {
             "properties": {
@@ -860,6 +870,18 @@
           "pattern": "^[a-z-]+$",
           "$comment": "MUST match CSS <line-style> keywords; native implementations map them to dash patterns or fall back to solid."
         },
+        "strokeStyle": {
+          "oneOf": [
+            { "$ref": "#/$defs/strokeStyle" },
+            {
+              "type": "object",
+              "required": ["$ref"],
+              "properties": { "$ref": { "$ref": "#/$defs/pointer" } },
+              "additionalProperties": false
+            }
+          ],
+          "$comment": "Optional strokeStyle metadata MUST capture dash, cap, and join semantics compatible with CSS border-image, SVG stroke, CAShapeLayer.lineDashPattern, and Android Paint#setPathEffect."
+        },
         "color": {
           "$ref": "#/$defs/color",
           "$comment": "Border colour MUST conform to CSS <color> values and convert to CGColor or Android colour integers."
@@ -887,6 +909,58 @@
               "$comment": "Per-corner entries MUST follow border-radius semantics with names matching physical or logical corners."
             }
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "strokeStyle": {
+      "type": "object",
+      "minProperties": 1,
+      "properties": {
+        "dashArray": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "oneOf": [
+              {
+                "type": "number",
+                "minimum": 0,
+                "$comment": "Numeric dash intervals MUST follow the <number> grammar used by SVG stroke-dasharray and CanvasRenderingContext2D.setLineDash."
+              },
+              {
+                "$ref": "#/$defs/length-dimension",
+                "$comment": "Length dash intervals MUST conform to the <length> production accepted by SVG stroke-dasharray and CSS border-image repeat lengths."
+              }
+            ]
+          },
+          "$comment": "Sequence of dash and gap lengths MUST follow SVG stroke-dasharray semantics and map to CAShapeLayer.lineDashPattern and Android DashPathEffect intervals."
+        },
+        "dashOffset": {
+          "oneOf": [
+            {
+              "type": "number",
+              "$comment": "Numeric offsets MUST follow the <number> grammar from SVG stroke-dashoffset representing multiples of the stroke width."
+            },
+            {
+              "$ref": "#/$defs/length-dimension",
+              "$comment": "Length offsets MUST conform to CSS <length> semantics for stroke-dashoffset and native stroke APIs."
+            }
+          ]
+        },
+        "lineCap": {
+          "type": "string",
+          "enum": ["butt", "round", "square"],
+          "$comment": "Line caps MUST match the <stroke-linecap> keywords butt, round, or square defined by SVG and Canvas 2D."
+        },
+        "lineJoin": {
+          "type": "string",
+          "enum": ["miter", "round", "bevel"],
+          "$comment": "Line joins MUST match the <stroke-linejoin> keywords miter, round, or bevel defined by SVG and Canvas 2D."
+        },
+        "miterLimit": {
+          "type": "number",
+          "minimum": 1,
+          "$comment": "Miter limits MUST be >= 1 following SVG stroke-miterlimit and CanvasRenderingContext2D.miterLimit semantics."
         }
       },
       "additionalProperties": false

--- a/tests/fixtures/negative/stroke-style-invalid/expected.error.json
+++ b/tests/fixtures/negative/stroke-style-invalid/expected.error.json
@@ -1,0 +1,1 @@
+{ "message": "must be equal to one of the allowed values" }

--- a/tests/fixtures/negative/stroke-style-invalid/input.json
+++ b/tests/fixtures/negative/stroke-style-invalid/input.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "border": {
+    "invalid": {
+      "$type": "border",
+      "$value": {
+        "borderType": "css.border",
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0.2, 0.2, 0.2, 1.0]
+        },
+        "style": "solid",
+        "strokeStyle": {
+          "dashArray": [2, -1],
+          "lineCap": "triangle"
+        },
+        "width": { "dimensionType": "length", "value": 1, "unit": "px" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/stroke-style-invalid/meta.yaml
+++ b/tests/fixtures/negative/stroke-style-invalid/meta.yaml
@@ -1,0 +1,5 @@
+name: stroke-style-invalid
+description: strokeStyle must use non-negative dash arrays and known cap keywords
+assertions:
+  - schema
+tags: [border]

--- a/tests/fixtures/negative/stroke-style-ref-type/expected.error.json
+++ b/tests/fixtures/negative/stroke-style-ref-type/expected.error.json
@@ -1,0 +1,3 @@
+{
+  "message": "border strokeStyle $ref #/color/accent has type color, expected strokeStyle"
+}

--- a/tests/fixtures/negative/stroke-style-ref-type/input.json
+++ b/tests/fixtures/negative/stroke-style-ref-type/input.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "color": {
+    "accent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.5, 0.1, 0.9, 1.0]
+      }
+    }
+  },
+  "border": {
+    "invalid-stroke": {
+      "$type": "border",
+      "$value": {
+        "borderType": "css.border",
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0.0, 0.0, 0.0, 1.0]
+        },
+        "style": "solid",
+        "strokeStyle": { "$ref": "#/color/accent" },
+        "width": { "dimensionType": "length", "value": 1, "unit": "px" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/stroke-style-ref-type/meta.yaml
+++ b/tests/fixtures/negative/stroke-style-ref-type/meta.yaml
@@ -1,0 +1,3 @@
+name: stroke-style-ref-type
+description: strokeStyle references must target strokeStyle tokens
+tags: [border]

--- a/tests/fixtures/positive/stroke-style/expected.json
+++ b/tests/fixtures/positive/stroke-style/expected.json
@@ -1,0 +1,57 @@
+{
+  "border": {
+    "focus-outline": {
+      "$type": "border",
+      "$value": {
+        "borderType": "css.border",
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0.0, 0.435, 1.0, 1.0]
+        },
+        "style": "solid",
+        "strokeStyle": {
+          "$type": "strokeStyle",
+          "$value": {
+            "dashArray": [4, { "dimensionType": "length", "value": 3, "unit": "px" }],
+            "dashOffset": { "dimensionType": "length", "value": 1, "unit": "pt" },
+            "lineCap": "round",
+            "lineJoin": "bevel",
+            "miterLimit": 2
+          }
+        },
+        "width": { "dimensionType": "length", "value": 2, "unit": "px" }
+      }
+    },
+    "inline": {
+      "$type": "border",
+      "$value": {
+        "borderType": "ios.layer",
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0.1, 0.2, 0.3, 1.0]
+        },
+        "style": "dashed",
+        "strokeStyle": {
+          "dashArray": [2, 1.5],
+          "dashOffset": 0.5,
+          "lineCap": "square",
+          "lineJoin": "miter",
+          "miterLimit": 4
+        },
+        "width": { "dimensionType": "length", "value": 1, "unit": "pt" }
+      }
+    }
+  },
+  "strokeStyle": {
+    "focus": {
+      "$type": "strokeStyle",
+      "$value": {
+        "dashArray": [4, { "dimensionType": "length", "value": 3, "unit": "px" }],
+        "dashOffset": { "dimensionType": "length", "value": 1, "unit": "pt" },
+        "lineCap": "round",
+        "lineJoin": "bevel",
+        "miterLimit": 2
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/stroke-style/input.json
+++ b/tests/fixtures/positive/stroke-style/input.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "border": {
+    "focus-outline": {
+      "$type": "border",
+      "$value": {
+        "borderType": "css.border",
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0.0, 0.435, 1.0, 1.0]
+        },
+        "style": "solid",
+        "strokeStyle": { "$ref": "#/strokeStyle/focus" },
+        "width": { "dimensionType": "length", "value": 2, "unit": "px" }
+      }
+    },
+    "inline": {
+      "$type": "border",
+      "$value": {
+        "borderType": "ios.layer",
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0.1, 0.2, 0.3, 1.0]
+        },
+        "style": "dashed",
+        "strokeStyle": {
+          "dashArray": [2, 1.5],
+          "dashOffset": 0.5,
+          "lineCap": "square",
+          "lineJoin": "miter",
+          "miterLimit": 4
+        },
+        "width": { "dimensionType": "length", "value": 1, "unit": "pt" }
+      }
+    }
+  },
+  "strokeStyle": {
+    "focus": {
+      "$type": "strokeStyle",
+      "$value": {
+        "dashArray": [4, { "dimensionType": "length", "value": 3, "unit": "px" }],
+        "dashOffset": { "dimensionType": "length", "value": 1, "unit": "pt" },
+        "lineCap": "round",
+        "lineJoin": "bevel",
+        "miterLimit": 2
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/stroke-style/meta.yaml
+++ b/tests/fixtures/positive/stroke-style/meta.yaml
@@ -1,0 +1,7 @@
+name: stroke-style
+description: strokeStyle tokens and borders with structured dash metadata
+assertions:
+  - schema
+  - type-compat
+  - refs
+tags: [border]

--- a/tests/tooling/assert-type-compat.mjs
+++ b/tests/tooling/assert-type-compat.mjs
@@ -446,6 +446,32 @@ export default function assertTypeCompat(doc) {
           }
         }
       }
+      if (node.$type === 'border' && node.$value && typeof node.$value === 'object') {
+        const stroke = node.$value.strokeStyle;
+        if (
+          stroke &&
+          typeof stroke === 'object' &&
+          Object.prototype.hasOwnProperty.call(stroke, '$ref') &&
+          typeof stroke.$ref === 'string'
+        ) {
+          const { type: strokeType } = getTokenTypeInfo(doc, stroke.$ref, new Set());
+          const errorBase = {
+            code: 'E_BORDER_STROKE_STYLE_TYPE',
+            path: `${path}/$value/strokeStyle/$ref`
+          };
+          if (!strokeType) {
+            errors.push({
+              ...errorBase,
+              message: `border strokeStyle $ref ${stroke.$ref} must resolve to a token that declares $type strokeStyle`
+            });
+          } else if (strokeType !== 'strokeStyle') {
+            errors.push({
+              ...errorBase,
+              message: `border strokeStyle $ref ${stroke.$ref} has type ${strokeType}, expected strokeStyle`
+            });
+          }
+        }
+      }
       if (node.$type === 'component' && node.$value && typeof node.$value === 'object') {
         const slots = node.$value.$slots;
         if (slots && typeof slots === 'object') {


### PR DESCRIPTION
## Summary
- add a strokeStyle definition to the core schema, allow borders to reference it, and teach the validator about the new type
- document strokeStyle usage across the spec, guides, and examples while updating migration guidance and registry metadata
- provide positive and negative fixtures covering strokeStyle payloads and refresh example tokens to exercise the new structure

## Testing
- npm test
- npm run lint
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68cd80b068fc8328b456be09f26adacf