### PR TITLE
Support layered shadow values

### DIFF
--- a/docs/guides/migrating-from-dtcg.md
+++ b/docs/guides/migrating-from-dtcg.md
@@ -559,6 +559,13 @@ extensions for dash patterns.
           "offsetY": { "value": 2, "unit": "px" },
           "blur": { "value": 6, "unit": "px" },
           "spread": { "value": 0, "unit": "px" }
+        },
+        {
+          "color": "#0000004d",
+          "offsetX": { "value": 0, "unit": "px" },
+          "offsetY": { "value": 1, "unit": "px" },
+          "blur": { "value": 3, "unit": "px" },
+          "spread": { "value": 0, "unit": "px" }
         }
       ]
     }
@@ -574,40 +581,70 @@ extensions for dash patterns.
   "shadow": {
     "button-ambient": {
       "$type": "shadow",
-      "$value": {
-        "shadowType": "css.box-shadow",
-        "offsetX": {
-          "dimensionType": "length",
-          "value": 0,
-          "unit": "px"
+      "$value": [
+        {
+          "shadowType": "css.box-shadow",
+          "offsetX": {
+            "dimensionType": "length",
+            "value": 0,
+            "unit": "px"
+          },
+          "offsetY": {
+            "dimensionType": "length",
+            "value": 2,
+            "unit": "px"
+          },
+          "blur": {
+            "dimensionType": "length",
+            "value": 6,
+            "unit": "px"
+          },
+          "spread": {
+            "dimensionType": "length",
+            "value": 0,
+            "unit": "px"
+          },
+          "color": {
+            "colorSpace": "srgb",
+            "components": [0.0, 0.0, 0.0, 0.2]
+          }
         },
-        "offsetY": {
-          "dimensionType": "length",
-          "value": 2,
-          "unit": "px"
-        },
-        "blur": {
-          "dimensionType": "length",
-          "value": 6,
-          "unit": "px"
-        },
-        "spread": {
-          "dimensionType": "length",
-          "value": 0,
-          "unit": "px"
-        },
-        "color": {
-          "colorSpace": "srgb",
-          "components": [0.0, 0.0, 0.0, 0.2]
+        {
+          "shadowType": "css.box-shadow",
+          "offsetX": {
+            "dimensionType": "length",
+            "value": 0,
+            "unit": "px"
+          },
+          "offsetY": {
+            "dimensionType": "length",
+            "value": 1,
+            "unit": "px"
+          },
+          "blur": {
+            "dimensionType": "length",
+            "value": 3,
+            "unit": "px"
+          },
+          "spread": {
+            "dimensionType": "length",
+            "value": 0,
+            "unit": "px"
+          },
+          "color": {
+            "colorSpace": "srgb",
+            "components": [0.0, 0.0, 0.0, 0.3]
+          }
         }
-      }
+      ]
     }
   }
 }
 ```
 
-Convert shadow arrays into DTIF objects with explicit `shadowType` strings and dimension
-wrappers for each offset.
+Convert each DTCG layer into a DTIF shadow object with an explicit `shadowType` and
+dimension wrappers. Tokens with multiple layers continue to use arrays whose ordering
+matches the original DTCG payload.
 
 ### Gradients {#gradients}
 

--- a/docs/spec/token-types.md
+++ b/docs/spec/token-types.md
@@ -624,12 +624,15 @@ lineDashPhase, Core Graphics line cap/join enums, and Android
 ### `shadow` tokens {#shadow-tokens}
 
 `shadow` tokens describe blurred occlusion or glow effects. Their
-`$value` object _MUST_ include a string
+`$value` _MAY_ be either a single shadow-layer object or an array of
+layer objects following the ordering rules of the CSS
+`<shadow>` grammar. Each layer _MUST_ include a string
 `shadowType`, length-valued `offsetX`, `offsetY`, and
 `blur` members, and a `color`. Producers
-_MAY_ include an optional `spread` length matching
+_MAY_ include an optional `spread` length on each layer matching
 the final argument of the
-`<shadow>` grammar.
+`<shadow>` grammar. Layer arrays _MUST_ contain at
+least one entry.
 
 The `shadowType` string identifies the rendering context and
 _MUST_ match the terminology defined by the relevant platform
@@ -646,7 +649,7 @@ NSShadow APIs, and Android
 View#setElevation or
 Paint#setShadowLayer.
 
-| Member               | CSS grammar                                                                                                              | iOS mapping                                                                                | Android mapping                                                                                                              |
+| Layer member         | CSS grammar                                                                                                              | iOS mapping                                                                                | Android mapping                                                                                                              |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
 | `shadowType`         | Context keywords from the `<shadow>` grammar, including the optional `inset` modifier and `drop-shadow()` function name. | Chooses between outer shadows provided by CALayer and text shadows provided by NSShadow.   | Selects View#setElevation based outlines or Paint#setShadowLayer for text and vector content.                                |
 | `offsetX`, `offsetY` | The first two `<length>` components of a `<shadow>`.                                                                     | Map to the horizontal and vertical components of CALayer.shadowOffset expressed in points. | Supply the `dx` and `dy` parameters for Paint#setShadowLayer or inform the outline offset for View elevations.               |

--- a/examples/dtcg-migration/shadow.tokens.json
+++ b/examples/dtcg-migration/shadow.tokens.json
@@ -3,33 +3,62 @@
   "shadow": {
     "button-ambient": {
       "$type": "shadow",
-      "$value": {
-        "shadowType": "css.box-shadow",
-        "offsetX": {
-          "dimensionType": "length",
-          "value": 0,
-          "unit": "px"
+      "$value": [
+        {
+          "shadowType": "css.box-shadow",
+          "offsetX": {
+            "dimensionType": "length",
+            "value": 0,
+            "unit": "px"
+          },
+          "offsetY": {
+            "dimensionType": "length",
+            "value": 2,
+            "unit": "px"
+          },
+          "blur": {
+            "dimensionType": "length",
+            "value": 6,
+            "unit": "px"
+          },
+          "spread": {
+            "dimensionType": "length",
+            "value": 0,
+            "unit": "px"
+          },
+          "color": {
+            "colorSpace": "srgb",
+            "components": [0.0, 0.0, 0.0, 0.2]
+          }
         },
-        "offsetY": {
-          "dimensionType": "length",
-          "value": 2,
-          "unit": "px"
-        },
-        "blur": {
-          "dimensionType": "length",
-          "value": 6,
-          "unit": "px"
-        },
-        "spread": {
-          "dimensionType": "length",
-          "value": 0,
-          "unit": "px"
-        },
-        "color": {
-          "colorSpace": "srgb",
-          "components": [0.0, 0.0, 0.0, 0.2]
+        {
+          "shadowType": "css.box-shadow",
+          "offsetX": {
+            "dimensionType": "length",
+            "value": 0,
+            "unit": "px"
+          },
+          "offsetY": {
+            "dimensionType": "length",
+            "value": 1,
+            "unit": "px"
+          },
+          "blur": {
+            "dimensionType": "length",
+            "value": 3,
+            "unit": "px"
+          },
+          "spread": {
+            "dimensionType": "length",
+            "value": 0,
+            "unit": "px"
+          },
+          "color": {
+            "colorSpace": "srgb",
+            "components": [0.0, 0.0, 0.0, 0.3]
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/schema/core.json
+++ b/schema/core.json
@@ -972,6 +972,16 @@
       "additionalProperties": false
     },
     "shadow": {
+      "oneOf": [
+        { "$ref": "#/$defs/shadow-layer" },
+        {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/shadow-layer" }
+        }
+      ]
+    },
+    "shadow-layer": {
       "type": "object",
       "required": ["shadowType", "offsetX", "offsetY", "blur", "color"],
       "properties": {

--- a/tests/fixtures/negative/shadow-layer-empty/expected.error.json
+++ b/tests/fixtures/negative/shadow-layer-empty/expected.error.json
@@ -1,0 +1,3 @@
+{
+  "message": "must NOT have fewer than 1 items"
+}

--- a/tests/fixtures/negative/shadow-layer-empty/input.json
+++ b/tests/fixtures/negative/shadow-layer-empty/input.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "shadow": {
+    "bad": {
+      "$type": "shadow",
+      "$value": []
+    }
+  }
+}

--- a/tests/fixtures/negative/shadow-layer-empty/meta.yaml
+++ b/tests/fixtures/negative/shadow-layer-empty/meta.yaml
@@ -1,0 +1,5 @@
+name: shadow-layer-empty
+description: shadow arrays must include at least one layer
+assertions:
+  - schema
+tags: [shadow]

--- a/tests/fixtures/negative/shadow-layer-missing-type/expected.error.json
+++ b/tests/fixtures/negative/shadow-layer-missing-type/expected.error.json
@@ -1,0 +1,3 @@
+{
+  "message": "must have required property 'shadowType'"
+}

--- a/tests/fixtures/negative/shadow-layer-missing-type/input.json
+++ b/tests/fixtures/negative/shadow-layer-missing-type/input.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "shadow": {
+    "bad": {
+      "$type": "shadow",
+      "$value": [
+        {
+          "shadowType": "css.box-shadow",
+          "offsetX": { "dimensionType": "length", "value": 0, "unit": "px" },
+          "offsetY": { "dimensionType": "length", "value": 2, "unit": "px" },
+          "blur": { "dimensionType": "length", "value": 6, "unit": "px" },
+          "color": {
+            "colorSpace": "srgb",
+            "components": [0, 0, 0, 0.2]
+          }
+        },
+        {
+          "offsetX": { "dimensionType": "length", "value": 0, "unit": "px" },
+          "offsetY": { "dimensionType": "length", "value": 1, "unit": "px" },
+          "blur": { "dimensionType": "length", "value": 3, "unit": "px" },
+          "color": {
+            "colorSpace": "srgb",
+            "components": [0, 0, 0, 0.3]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/fixtures/negative/shadow-layer-missing-type/meta.yaml
+++ b/tests/fixtures/negative/shadow-layer-missing-type/meta.yaml
@@ -1,0 +1,5 @@
+name: shadow-layer-missing-type
+description: each shadow layer requires a shadowType
+assertions:
+  - schema
+tags: [shadow]

--- a/tests/fixtures/positive/shadow/expected.json
+++ b/tests/fixtures/positive/shadow/expected.json
@@ -23,5 +23,59 @@
         "unit": "px"
       }
     }
+  },
+  "cardRaised": {
+    "$type": "shadow",
+    "$value": [
+      {
+        "shadowType": "css.box-shadow",
+        "blur": {
+          "dimensionType": "length",
+          "value": 6,
+          "unit": "px"
+        },
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0, 0.18]
+        },
+        "offsetX": {
+          "dimensionType": "length",
+          "value": 0,
+          "unit": "px"
+        },
+        "offsetY": {
+          "dimensionType": "length",
+          "value": 2,
+          "unit": "px"
+        },
+        "spread": {
+          "dimensionType": "length",
+          "value": 0,
+          "unit": "px"
+        }
+      },
+      {
+        "shadowType": "css.box-shadow",
+        "blur": {
+          "dimensionType": "length",
+          "value": 12,
+          "unit": "px"
+        },
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0, 0.22]
+        },
+        "offsetX": {
+          "dimensionType": "length",
+          "value": 0,
+          "unit": "px"
+        },
+        "offsetY": {
+          "dimensionType": "length",
+          "value": 4,
+          "unit": "px"
+        }
+      }
+    ]
   }
 }

--- a/tests/fixtures/positive/shadow/input.json
+++ b/tests/fixtures/positive/shadow/input.json
@@ -24,5 +24,59 @@
         "unit": "px"
       }
     }
+  },
+  "cardRaised": {
+    "$type": "shadow",
+    "$value": [
+      {
+        "shadowType": "css.box-shadow",
+        "blur": {
+          "dimensionType": "length",
+          "value": 6,
+          "unit": "px"
+        },
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0, 0.18]
+        },
+        "offsetX": {
+          "dimensionType": "length",
+          "value": 0,
+          "unit": "px"
+        },
+        "offsetY": {
+          "dimensionType": "length",
+          "value": 2,
+          "unit": "px"
+        },
+        "spread": {
+          "dimensionType": "length",
+          "value": 0,
+          "unit": "px"
+        }
+      },
+      {
+        "shadowType": "css.box-shadow",
+        "blur": {
+          "dimensionType": "length",
+          "value": 12,
+          "unit": "px"
+        },
+        "color": {
+          "colorSpace": "srgb",
+          "components": [0, 0, 0, 0.22]
+        },
+        "offsetX": {
+          "dimensionType": "length",
+          "value": 0,
+          "unit": "px"
+        },
+        "offsetY": {
+          "dimensionType": "length",
+          "value": 4,
+          "unit": "px"
+        }
+      }
+    ]
   }
 }

--- a/tests/fixtures/positive/shadow/meta.yaml
+++ b/tests/fixtures/positive/shadow/meta.yaml
@@ -1,5 +1,5 @@
 name: shadow
-description: valid shadow tokens
+description: valid shadow tokens, including layered arrays
 assertions:
   - schema
   - type-compat


### PR DESCRIPTION
## Summary
- allow `shadow` token values to be described either as a single layer object or an ordered array of layer objects in the schema
- document layered shadow payloads in the spec and migration guide and refresh the DTCG migration example
- add fixtures that cover valid layered shadows and invalid empty or incomplete layer arrays

## Testing
- npm test
- npm run format
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd9f6db8cc83289cef260c45301f51