### PR TITLE
Allow composite tokens to reuse referenced values

### DIFF
--- a/docs/guides/migrating-from-dtcg.md
+++ b/docs/guides/migrating-from-dtcg.md
@@ -443,23 +443,43 @@ Wrap each duration with a `durationType` identifier and promote Bézier arrays t
       }
     }
   },
+  "dimension": {
+    "typography": {
+      "body-size": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 16,
+          "unit": "px"
+        }
+      },
+      "body-letter-spacing": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 0.5,
+          "unit": "px"
+        }
+      },
+      "body-line-height": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 24,
+          "unit": "px"
+        }
+      }
+    }
+  },
   "typography": {
     "body": {
       "$type": "typography",
       "$value": {
         "fontFamily": "Inter",
         "fontWeight": 400,
-        "fontSize": {
-          "dimensionType": "length",
-          "value": 16,
-          "unit": "px"
-        },
-        "letterSpacing": {
-          "dimensionType": "length",
-          "value": 0.5,
-          "unit": "px"
-        },
-        "lineHeight": 1.5
+        "fontSize": { "$ref": "#/dimension/typography/body-size" },
+        "letterSpacing": { "$ref": "#/dimension/typography/body-letter-spacing" },
+        "lineHeight": { "$ref": "#/dimension/typography/body-line-height" }
       }
     }
   }
@@ -467,8 +487,9 @@ Wrap each duration with a `durationType` identifier and promote Bézier arrays t
 ```
 
 Consolidate font metadata into a reusable `font` token, encode fallback stacks with the
-`fallbacks` property, and replace `{token.reference}` strings with `$ref` pointers wherever DTIF expects nested
-objects such as shared dimensions or colours.
+`fallbacks` property, and promote repeated measurements to standalone `dimension` tokens.
+Reference those measurements from `typography` tokens via `$ref` so existing aliases remain
+intact during the migration.
 
 ## Convert composite tokens {#composite-tokens}
 
@@ -481,6 +502,15 @@ richer schemas for these structures.
 
 ```json
 {
+  "color": {
+    "focus": { "$type": "color", "$value": "#006FFF" }
+  },
+  "dimension": {
+    "focus-outline-width": {
+      "$type": "dimension",
+      "$value": { "value": 2, "unit": "px" }
+    }
+  },
   "strokeStyle": {
     "focus": {
       "$type": "strokeStyle",
@@ -494,9 +524,9 @@ richer schemas for these structures.
     "focus-outline": {
       "$type": "border",
       "$value": {
-        "color": "#006FFF",
+        "color": "{color.focus}",
         "style": "solid",
-        "width": { "value": 2, "unit": "px" }
+        "width": "{dimension.focus-outline-width}"
       }
     }
   }
@@ -508,6 +538,25 @@ richer schemas for these structures.
 ```json
 {
   "$version": "1.0.0",
+  "color": {
+    "focus-outline": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.0, 0.435, 1.0, 1.0]
+      }
+    }
+  },
+  "dimension": {
+    "focus-outline-width": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 2,
+        "unit": "px"
+      }
+    }
+  },
   "strokeStyle": {
     "focus": {
       "$type": "strokeStyle",
@@ -522,22 +571,19 @@ richer schemas for these structures.
       "$type": "border",
       "$value": {
         "borderType": "css.border",
-        "color": {
-          "colorSpace": "srgb",
-          "components": [0.0, 0.435, 1.0, 1.0]
-        },
+        "color": { "$ref": "#/color/focus-outline" },
         "style": "solid",
         "strokeStyle": { "$ref": "#/strokeStyle/focus" },
-        "width": {
-          "dimensionType": "length",
-          "value": 2,
-          "unit": "px"
-        }
+        "width": { "$ref": "#/dimension/focus-outline-width" }
       }
     }
   }
 }
 ```
+
+The shared `color` and `dimension` entries become standalone DTIF tokens that
+the border references through `$ref` pointers, preserving the original DTCG
+aliases while exposing richer metadata.
 
 DTIF `border` tokens capture the rendering context through `borderType`, reuse
 stroke metadata via a first-class `strokeStyle` token, and avoid vendor
@@ -549,23 +595,53 @@ extensions for dash patterns.
 
 ```json
 {
+  "color": {
+    "shadow": {
+      "ambient": { "$type": "color", "$value": "#00000033" },
+      "key": { "$type": "color", "$value": "#0000004d" }
+    }
+  },
+  "dimension": {
+    "shadow": {
+      "offset-large": {
+        "$type": "dimension",
+        "$value": { "value": 2, "unit": "px" }
+      },
+      "offset-small": {
+        "$type": "dimension",
+        "$value": { "value": 1, "unit": "px" }
+      },
+      "blur-large": {
+        "$type": "dimension",
+        "$value": { "value": 6, "unit": "px" }
+      },
+      "blur-small": {
+        "$type": "dimension",
+        "$value": { "value": 3, "unit": "px" }
+      },
+      "spread": {
+        "$type": "dimension",
+        "$value": { "value": 0, "unit": "px" }
+      }
+    }
+  },
   "shadow": {
     "button-ambient": {
       "$type": "shadow",
       "$value": [
         {
-          "color": "#00000080",
-          "offsetX": { "value": 0, "unit": "px" },
-          "offsetY": { "value": 2, "unit": "px" },
-          "blur": { "value": 6, "unit": "px" },
-          "spread": { "value": 0, "unit": "px" }
+          "color": "{color.shadow.ambient}",
+          "offsetX": "{dimension.shadow.spread}",
+          "offsetY": "{dimension.shadow.offset-large}",
+          "blur": "{dimension.shadow.blur-large}",
+          "spread": "{dimension.shadow.spread}"
         },
         {
-          "color": "#0000004d",
-          "offsetX": { "value": 0, "unit": "px" },
-          "offsetY": { "value": 1, "unit": "px" },
-          "blur": { "value": 3, "unit": "px" },
-          "spread": { "value": 0, "unit": "px" }
+          "color": "{color.shadow.key}",
+          "offsetX": "{dimension.shadow.spread}",
+          "offsetY": "{dimension.shadow.offset-small}",
+          "blur": "{dimension.shadow.blur-small}",
+          "spread": "{dimension.shadow.spread}"
         }
       ]
     }
@@ -578,69 +654,93 @@ extensions for dash patterns.
 ```json
 {
   "$version": "1.0.0",
+  "color": {
+    "shadow-ambient": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.0, 0.0, 0.0, 0.2]
+      }
+    },
+    "shadow-key": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.0, 0.0, 0.0, 0.3]
+      }
+    }
+  },
+  "dimension": {
+    "shadow-offset-large": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 2,
+        "unit": "px"
+      }
+    },
+    "shadow-offset-small": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 1,
+        "unit": "px"
+      }
+    },
+    "shadow-blur-large": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 6,
+        "unit": "px"
+      }
+    },
+    "shadow-blur-small": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 3,
+        "unit": "px"
+      }
+    },
+    "shadow-spread": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 0,
+        "unit": "px"
+      }
+    }
+  },
   "shadow": {
     "button-ambient": {
       "$type": "shadow",
       "$value": [
         {
           "shadowType": "css.box-shadow",
-          "offsetX": {
-            "dimensionType": "length",
-            "value": 0,
-            "unit": "px"
-          },
-          "offsetY": {
-            "dimensionType": "length",
-            "value": 2,
-            "unit": "px"
-          },
-          "blur": {
-            "dimensionType": "length",
-            "value": 6,
-            "unit": "px"
-          },
-          "spread": {
-            "dimensionType": "length",
-            "value": 0,
-            "unit": "px"
-          },
-          "color": {
-            "colorSpace": "srgb",
-            "components": [0.0, 0.0, 0.0, 0.2]
-          }
+          "offsetX": { "$ref": "#/dimension/shadow-spread" },
+          "offsetY": { "$ref": "#/dimension/shadow-offset-large" },
+          "blur": { "$ref": "#/dimension/shadow-blur-large" },
+          "spread": { "$ref": "#/dimension/shadow-spread" },
+          "color": { "$ref": "#/color/shadow-ambient" }
         },
         {
           "shadowType": "css.box-shadow",
-          "offsetX": {
-            "dimensionType": "length",
-            "value": 0,
-            "unit": "px"
-          },
-          "offsetY": {
-            "dimensionType": "length",
-            "value": 1,
-            "unit": "px"
-          },
-          "blur": {
-            "dimensionType": "length",
-            "value": 3,
-            "unit": "px"
-          },
-          "spread": {
-            "dimensionType": "length",
-            "value": 0,
-            "unit": "px"
-          },
-          "color": {
-            "colorSpace": "srgb",
-            "components": [0.0, 0.0, 0.0, 0.3]
-          }
+          "offsetX": { "$ref": "#/dimension/shadow-spread" },
+          "offsetY": { "$ref": "#/dimension/shadow-offset-small" },
+          "blur": { "$ref": "#/dimension/shadow-blur-small" },
+          "spread": { "$ref": "#/dimension/shadow-spread" },
+          "color": { "$ref": "#/color/shadow-key" }
         }
       ]
     }
   }
 }
 ```
+
+Shared colour and dimension primitives become first-class DTIF tokens that
+each shadow layer references via `$ref`, preserving the alias relationships
+used in the source DTCG document.
 
 Convert each DTCG layer into a DTIF shadow object with an explicit `shadowType` and
 dimension wrappers. Tokens with multiple layers continue to use arrays whose ordering
@@ -673,6 +773,22 @@ matches the original DTCG payload.
 ```json
 {
   "$version": "1.0.0",
+  "color": {
+    "hero-start": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [1.0, 0.541, 0.0, 1.0]
+      }
+    },
+    "hero-end": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.929, 0.098, 0.792, 1.0]
+      }
+    }
+  },
   "gradient": {
     "hero-background": {
       "$type": "gradient",
@@ -680,20 +796,8 @@ matches the original DTCG payload.
         "gradientType": "linear",
         "angle": "to top right",
         "stops": [
-          {
-            "position": "0%",
-            "color": {
-              "colorSpace": "srgb",
-              "components": [1.0, 0.541, 0.0, 1.0]
-            }
-          },
-          {
-            "position": "100%",
-            "color": {
-              "colorSpace": "srgb",
-              "components": [0.929, 0.098, 0.792, 1.0]
-            }
-          }
+          { "position": "0%", "color": { "$ref": "#/color/hero-start" } },
+          { "position": "100%", "color": { "$ref": "#/color/hero-end" } }
         ]
       }
     }
@@ -701,8 +805,9 @@ matches the original DTCG payload.
 }
 ```
 
-Normalise stop positions to percentages, map angles to CSS syntax, and encode each colour
-using DTIF's colour structure.
+Normalise stop positions to percentages, map angles to CSS syntax, and mint shared
+`color` tokens that gradient stops reference through `$ref` so palette aliases survive the
+migration.
 
 ### Transitions and motion {#transitions}
 

--- a/docs/spec/token-types.md
+++ b/docs/spec/token-types.md
@@ -532,6 +532,10 @@ GradientDrawable#setStroke.
 | `color`       | `border-color` using `<color>` values.                                                            | CALayer.borderColor (`CGColor`).                                               | Colour argument of GradientDrawable#setStroke.                                                |
 | `radius`      | `border-radius` shorthand and `border-*-radius` longhands.                                        | CALayer.cornerRadius and UIBezierPath rounded-rect paths for per-corner radii. | GradientDrawable#setCornerRadius and `setCornerRadii` arrays.                                 |
 
+`color` and `width` MAY appear as alias objects whose only member is `$ref`. Those
+aliases _MUST_ resolve to `color` and `dimension` tokens so that palette and spacing
+values can be shared across borders without duplicating their payloads.
+
 The `width` member _MUST_ use values that conform to
 the
 `<line-width>`
@@ -657,6 +661,10 @@ Paint#setShadowLayer.
 | `spread`             | Optional final `<length>` in `<shadow>`.                                                                                 | Consumers _MUST_ express spread by adjusting CALayer.shadowPath or related masks.          | Implemented via outline manipulation using ViewOutlineProvider or vector path inflation before calling Paint#setShadowLayer. |
 | `color`              | `<color>` values inside `<shadow>`.                                                                                      | Converted to `CGColor` instances applied to CALayer.shadowColor or NSShadow.shadowColor.   | Packed into ARGB integers for Paint#setShadowLayer or elevation ambient/spot colours.                                        |
 
+`offsetX`, `offsetY`, `blur`, `spread`, and `color` MAY be alias objects with only `$ref`. These aliases
+_MUST_ resolve to `dimension` or `color` tokens so the same measurements or palette entries can be reused
+across multiple shadow layers.
+
 Offsets, blur radii, and spreads _MUST_ use values conforming
 to the `<length>` production or
 platform-native units such as iOS points defined in
@@ -697,6 +705,9 @@ Gradient member references
 | `stops[].position` | `<color-stop-length>` from the `<color-stop-list>` grammar.                   | Normalised offsets mapped to `locations` on CAGradientLayer.                                                 | Stop offsets supplied to shader position arrays for Android gradients.                            |
 | `stops[].hint`     | Optional `<color-hint>` values.                                               | Drives midpoint interpolation when converting to CAGradientLayer animation keyframes.                        | Translates to intermediate offsets for Android shader stop arrays.                                |
 | `stops[].color`    | `<color>` values.                                                             | Converted to `CGColor` instances on CAGradientLayer.                                                         | Packed into the colour arrays consumed by Android gradient shaders.                               |
+
+`stops[].color` MAY use an alias object containing only `$ref`. The pointer _MUST_ resolve to a
+`color` token so gradient stops can reuse shared palette entries without duplicating channel data.
 
 When authors provide `angle`, `center`, `shape`,
 `stops[].position`, or `stops[].hint` as strings they
@@ -896,6 +907,10 @@ members
 | `offset`        | Second `<length>` in the `<shadow>` production describing the vertical displacement; horizontal offset _MUST_ be zero for elevation contexts. | Maps to the `height` component of CALayer.shadowOffset with `width = 0`. | Provides the `dy` argument to Paint#setShadowLayer and, when targeting View#setElevation, the converted elevation distance.                                  |
 | `blur`          | Third `<length>` in the `<shadow>` grammar describing blur radius.                                                                            | Sets CALayer.shadowRadius in points.                                     | Supplies the `radius` argument to Paint#setShadowLayer; when using View#setElevation, it documents the expected ambient blur derived by the system renderer. |
 | `color`         | `<color>` values inside `<shadow>`.                                                                                                           | Converted to `CGColor` for CALayer.shadowColor or NSShadow.shadowColor.  | Packed into ARGB integers for Paint#setShadowLayer and to inform elevation overlay colours.                                                                  |
+
+`offset`, `blur`, and `color` MAY reuse shared measurements or palette entries by supplying alias
+objects whose only member is `$ref`. These aliases _MUST_ resolve to `dimension` and `color` tokens
+before consumers apply the elevation.
 
 Elevation offsets and blur radii _MUST_ use values conforming
 to the `<length>` production or

--- a/docs/spec/typography.md
+++ b/docs/spec/typography.md
@@ -120,6 +120,13 @@ Common optional properties defer to platform specifications as follows:
 - `overlineThickness` - `font-dimension`.
 - `overlineOffset` - `font-dimension`.
 
+Typography values _MAY_ reuse shared tokens via alias objects whose only member is
+`$ref`. These aliases _MUST_ resolve to tokens declaring the expected `$type`: `fontSize`,
+`letterSpacing`, `wordSpacing`, and `lineHeight` references _MUST_ point to `dimension`
+tokens whose `$value.dimensionType` is `"length"`, while `color` references _MUST_ point to
+`color` tokens. Consumers _MUST_ reject `$ref` targets that do not meet these
+requirements so typography tokens remain well-typed composites.
+
 The table below maps typography members to their authoritative references.
 
 _Table: Normative references for typography members._

--- a/examples/dtcg-migration/border.tokens.json
+++ b/examples/dtcg-migration/border.tokens.json
@@ -1,21 +1,33 @@
 {
   "$version": "1.0.0",
+  "color": {
+    "focus-outline": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.0, 0.435, 1.0, 1.0]
+      }
+    }
+  },
+  "dimension": {
+    "focus-outline-width": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 2,
+        "unit": "px"
+      }
+    }
+  },
   "border": {
     "focus-outline": {
       "$type": "border",
       "$value": {
         "borderType": "css.border",
-        "color": {
-          "colorSpace": "srgb",
-          "components": [0.0, 0.435, 1.0, 1.0]
-        },
+        "color": { "$ref": "#/color/focus-outline" },
         "style": "solid",
         "strokeStyle": { "$ref": "#/strokeStyle/focus" },
-        "width": {
-          "dimensionType": "length",
-          "value": 2,
-          "unit": "px"
-        }
+        "width": { "$ref": "#/dimension/focus-outline-width" }
       }
     }
   },

--- a/examples/dtcg-migration/gradient.tokens.json
+++ b/examples/dtcg-migration/gradient.tokens.json
@@ -1,5 +1,21 @@
 {
   "$version": "1.0.0",
+  "color": {
+    "hero-start": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [1.0, 0.541, 0.0, 1.0]
+      }
+    },
+    "hero-end": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.929, 0.098, 0.792, 1.0]
+      }
+    }
+  },
   "gradient": {
     "hero-background": {
       "$type": "gradient",
@@ -7,20 +23,8 @@
         "gradientType": "linear",
         "angle": "to top right",
         "stops": [
-          {
-            "position": "0%",
-            "color": {
-              "colorSpace": "srgb",
-              "components": [1.0, 0.541, 0.0, 1.0]
-            }
-          },
-          {
-            "position": "100%",
-            "color": {
-              "colorSpace": "srgb",
-              "components": [0.929, 0.098, 0.792, 1.0]
-            }
-          }
+          { "position": "0%", "color": { "$ref": "#/color/hero-start" } },
+          { "position": "100%", "color": { "$ref": "#/color/hero-end" } }
         ]
       }
     }

--- a/examples/dtcg-migration/shadow.tokens.json
+++ b/examples/dtcg-migration/shadow.tokens.json
@@ -1,62 +1,82 @@
 {
   "$version": "1.0.0",
+  "color": {
+    "shadow-ambient": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.0, 0.0, 0.0, 0.2]
+      }
+    },
+    "shadow-key": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.0, 0.0, 0.0, 0.3]
+      }
+    }
+  },
+  "dimension": {
+    "shadow-offset-large": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 2,
+        "unit": "px"
+      }
+    },
+    "shadow-offset-small": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 1,
+        "unit": "px"
+      }
+    },
+    "shadow-blur-large": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 6,
+        "unit": "px"
+      }
+    },
+    "shadow-blur-small": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 3,
+        "unit": "px"
+      }
+    },
+    "shadow-spread": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 0,
+        "unit": "px"
+      }
+    }
+  },
   "shadow": {
     "button-ambient": {
       "$type": "shadow",
       "$value": [
         {
           "shadowType": "css.box-shadow",
-          "offsetX": {
-            "dimensionType": "length",
-            "value": 0,
-            "unit": "px"
-          },
-          "offsetY": {
-            "dimensionType": "length",
-            "value": 2,
-            "unit": "px"
-          },
-          "blur": {
-            "dimensionType": "length",
-            "value": 6,
-            "unit": "px"
-          },
-          "spread": {
-            "dimensionType": "length",
-            "value": 0,
-            "unit": "px"
-          },
-          "color": {
-            "colorSpace": "srgb",
-            "components": [0.0, 0.0, 0.0, 0.2]
-          }
+          "offsetX": { "$ref": "#/dimension/shadow-spread" },
+          "offsetY": { "$ref": "#/dimension/shadow-offset-large" },
+          "blur": { "$ref": "#/dimension/shadow-blur-large" },
+          "spread": { "$ref": "#/dimension/shadow-spread" },
+          "color": { "$ref": "#/color/shadow-ambient" }
         },
         {
           "shadowType": "css.box-shadow",
-          "offsetX": {
-            "dimensionType": "length",
-            "value": 0,
-            "unit": "px"
-          },
-          "offsetY": {
-            "dimensionType": "length",
-            "value": 1,
-            "unit": "px"
-          },
-          "blur": {
-            "dimensionType": "length",
-            "value": 3,
-            "unit": "px"
-          },
-          "spread": {
-            "dimensionType": "length",
-            "value": 0,
-            "unit": "px"
-          },
-          "color": {
-            "colorSpace": "srgb",
-            "components": [0.0, 0.0, 0.0, 0.3]
-          }
+          "offsetX": { "$ref": "#/dimension/shadow-spread" },
+          "offsetY": { "$ref": "#/dimension/shadow-offset-small" },
+          "blur": { "$ref": "#/dimension/shadow-blur-small" },
+          "spread": { "$ref": "#/dimension/shadow-spread" },
+          "color": { "$ref": "#/color/shadow-key" }
         }
       ]
     }

--- a/examples/dtcg-migration/typography.tokens.json
+++ b/examples/dtcg-migration/typography.tokens.json
@@ -12,23 +12,43 @@
       }
     }
   },
+  "dimension": {
+    "typography": {
+      "body-size": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 16,
+          "unit": "px"
+        }
+      },
+      "body-letter-spacing": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 0.5,
+          "unit": "px"
+        }
+      },
+      "body-line-height": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 24,
+          "unit": "px"
+        }
+      }
+    }
+  },
   "typography": {
     "body": {
       "$type": "typography",
       "$value": {
         "fontFamily": "Inter",
         "fontWeight": 400,
-        "fontSize": {
-          "dimensionType": "length",
-          "value": 16,
-          "unit": "px"
-        },
-        "letterSpacing": {
-          "dimensionType": "length",
-          "value": 0.5,
-          "unit": "px"
-        },
-        "lineHeight": 1.5
+        "fontSize": { "$ref": "#/dimension/typography/body-size" },
+        "letterSpacing": { "$ref": "#/dimension/typography/body-letter-spacing" },
+        "lineHeight": { "$ref": "#/dimension/typography/body-line-height" }
       }
     }
   }

--- a/schema/core.json
+++ b/schema/core.json
@@ -32,6 +32,27 @@
         }
       ]
     },
+    "reference": {
+      "type": "object",
+      "required": ["$ref"],
+      "properties": { "$ref": { "$ref": "#/$defs/pointer" } },
+      "additionalProperties": false
+    },
+    "colorReference": {
+      "oneOf": [{ "$ref": "#/$defs/color" }, { "$ref": "#/$defs/reference" }]
+    },
+    "dimensionReference": {
+      "oneOf": [{ "$ref": "#/$defs/dimension" }, { "$ref": "#/$defs/reference" }]
+    },
+    "fontDimensionReference": {
+      "oneOf": [{ "$ref": "#/$defs/font-dimension" }, { "$ref": "#/$defs/reference" }]
+    },
+    "lengthDimensionReference": {
+      "oneOf": [{ "$ref": "#/$defs/length-dimension" }, { "$ref": "#/$defs/reference" }]
+    },
+    "angleDimensionReference": {
+      "oneOf": [{ "$ref": "#/$defs/angle-dimension" }, { "$ref": "#/$defs/reference" }]
+    },
     "css-ident": {
       "type": "string",
       "pattern": "^-{0,2}[A-Za-z_][A-Za-z0-9_-]*$",
@@ -735,25 +756,21 @@
           "description": "Canonical values such as 'body', 'heading', and 'caption' are registered. Custom values matching this pattern MAY be used; consumers MUST ignore unrecognised types to preserve compatibility."
         },
         "fontFamily": {
-          "oneOf": [
-            { "type": "string" },
-            {
-              "type": "object",
-              "required": ["$ref"],
-              "properties": { "$ref": { "$ref": "#/$defs/pointer" } },
-              "additionalProperties": false
-            }
-          ]
+          "oneOf": [{ "type": "string" }, { "$ref": "#/$defs/reference" }]
         },
-        "fontSize": { "$ref": "#/$defs/font-dimension" },
+        "fontSize": { "$ref": "#/$defs/fontDimensionReference" },
         "lineHeight": {
           "description": "Baseline-to-baseline distance as a ratio or font-dimension.",
           "oneOf": [
             { "$ref": "#/$defs/line-height" },
             {
               "allOf": [
-                { "$ref": "#/$defs/font-dimension" },
-                { "properties": { "value": { "minimum": 0 } } }
+                { "$ref": "#/$defs/fontDimensionReference" },
+                {
+                  "if": { "required": ["$ref"] },
+                  "then": {},
+                  "else": { "properties": { "value": { "minimum": 0 } } }
+                }
               ]
             }
           ]
@@ -761,7 +778,7 @@
         "letterSpacing": {
           "$comment": "MUST follow CSS letter-spacing grammar and reuse font-dimension unit conversions.",
           "oneOf": [
-            { "$ref": "#/$defs/font-dimension" },
+            { "$ref": "#/$defs/fontDimensionReference" },
             {
               "type": "string",
               "enum": ["normal"],
@@ -772,7 +789,7 @@
         "wordSpacing": {
           "$comment": "MUST conform to CSS word-spacing <length-percentage> grammar and platform unit semantics.",
           "oneOf": [
-            { "$ref": "#/$defs/font-dimension" },
+            { "$ref": "#/$defs/fontDimensionReference" },
             {
               "type": "string",
               "$comment": "MUST be the keyword 'normal' per CSS Text Module Level 3 word-spacing grammar."
@@ -811,7 +828,7 @@
           "type": "string",
           "$comment": "MUST conform to the CSS text-transform list grammar and preserve locale-sensitive casing."
         },
-        "color": { "$ref": "#/$defs/color" },
+        "color": { "$ref": "#/$defs/colorReference" },
         "fontFeatures": {
           "type": "array",
           "$comment": "MUST contain OpenType feature tags per CSS font-feature-settings and the OpenType registry.",
@@ -821,17 +838,17 @@
             "$comment": "MUST be a four-character OpenType feature tag registered by CSS font-feature-settings or documented by the font."
           }
         },
-        "underlineThickness": { "$ref": "#/$defs/font-dimension" },
-        "underlineOffset": { "$ref": "#/$defs/font-dimension" },
-        "overlineThickness": { "$ref": "#/$defs/font-dimension" },
-        "overlineOffset": { "$ref": "#/$defs/font-dimension" }
+        "underlineThickness": { "$ref": "#/$defs/fontDimensionReference" },
+        "underlineOffset": { "$ref": "#/$defs/fontDimensionReference" },
+        "overlineThickness": { "$ref": "#/$defs/fontDimensionReference" },
+        "overlineOffset": { "$ref": "#/$defs/fontDimensionReference" }
       },
       "additionalProperties": true
     },
     "borderCornerRadius": {
       "anyOf": [
         {
-          "$ref": "#/$defs/dimension",
+          "$ref": "#/$defs/dimensionReference",
           "$comment": "Single value MUST follow the <length-percentage> grammar defined for CSS border-radius."
         },
         {
@@ -839,11 +856,11 @@
           "required": ["x"],
           "properties": {
             "x": {
-              "$ref": "#/$defs/dimension",
+              "$ref": "#/$defs/dimensionReference",
               "$comment": "Horizontal radius MUST conform to CSS <length-percentage> and native point/density semantics."
             },
             "y": {
-              "$ref": "#/$defs/dimension",
+              "$ref": "#/$defs/dimensionReference",
               "$comment": "Optional vertical radius MUST conform to CSS <length-percentage>; when omitted, consumers reuse the horizontal value."
             }
           },
@@ -863,7 +880,7 @@
         },
         "width": {
           "oneOf": [
-            { "$ref": "#/$defs/dimension" },
+            { "$ref": "#/$defs/dimensionReference" },
             {
               "type": "string",
               "enum": ["thin", "medium", "thick"]
@@ -877,25 +894,17 @@
           "$comment": "MUST match CSS <line-style> keywords; native implementations map them to dash patterns or fall back to solid."
         },
         "strokeStyle": {
-          "oneOf": [
-            { "$ref": "#/$defs/strokeStyle" },
-            {
-              "type": "object",
-              "required": ["$ref"],
-              "properties": { "$ref": { "$ref": "#/$defs/pointer" } },
-              "additionalProperties": false
-            }
-          ],
+          "oneOf": [{ "$ref": "#/$defs/strokeStyle" }, { "$ref": "#/$defs/reference" }],
           "$comment": "Optional strokeStyle metadata MUST capture dash, cap, and join semantics compatible with CSS border-image, SVG stroke, CAShapeLayer.lineDashPattern, and Android Paint#setPathEffect."
         },
         "color": {
-          "$ref": "#/$defs/color",
+          "$ref": "#/$defs/colorReference",
           "$comment": "Border colour MUST conform to CSS <color> values and convert to CGColor or Android colour integers."
         },
         "radius": {
           "anyOf": [
             {
-              "$ref": "#/$defs/dimension",
+              "$ref": "#/$defs/dimensionReference",
               "$comment": "Uniform radius MUST follow the border-radius <length-percentage> grammar."
             },
             {
@@ -934,7 +943,7 @@
                 "$comment": "Numeric dash intervals MUST follow the <number> grammar used by SVG stroke-dasharray and CanvasRenderingContext2D.setLineDash."
               },
               {
-                "$ref": "#/$defs/length-dimension",
+                "$ref": "#/$defs/lengthDimensionReference",
                 "$comment": "Length dash intervals MUST conform to the <length> production accepted by SVG stroke-dasharray and CSS border-image repeat lengths."
               }
             ]
@@ -948,7 +957,7 @@
               "$comment": "Numeric offsets MUST follow the <number> grammar from SVG stroke-dashoffset representing multiples of the stroke width."
             },
             {
-              "$ref": "#/$defs/length-dimension",
+              "$ref": "#/$defs/lengthDimensionReference",
               "$comment": "Length offsets MUST conform to CSS <length> semantics for stroke-dashoffset and native stroke APIs."
             }
           ]
@@ -991,23 +1000,23 @@
           "$comment": "MUST identify the rendering context defined by CSS <shadow> grammars, UIKit CALayer/NSShadow APIs, or Android View/Paint shadow documentation (e.g. css.box-shadow, css.text-shadow, css.filter.drop-shadow, ios.layer, ios.text, android.view.elevation)."
         },
         "offsetX": {
-          "$ref": "#/$defs/length-dimension",
+          "$ref": "#/$defs/lengthDimensionReference",
           "$comment": "Horizontal offset MUST conform to CSS <length> or platform-native units such as points (pt) and density-independent pixels (dp)."
         },
         "offsetY": {
-          "$ref": "#/$defs/length-dimension",
+          "$ref": "#/$defs/lengthDimensionReference",
           "$comment": "Vertical offset MUST conform to CSS <length> or platform-native units such as points (pt) and density-independent pixels (dp)."
         },
         "blur": {
-          "$ref": "#/$defs/length-dimension",
+          "$ref": "#/$defs/lengthDimensionReference",
           "$comment": "Blur radius MUST match the <length> position in the CSS <shadow> production or equivalent CALayer.shadowRadius / Paint#setShadowLayer radius semantics."
         },
         "spread": {
-          "$ref": "#/$defs/length-dimension",
+          "$ref": "#/$defs/lengthDimensionReference",
           "$comment": "Optional spread MUST follow the final <length> of CSS <shadow> and is realised via CALayer.shadowPath or Android outline inflation."
         },
         "color": {
-          "$ref": "#/$defs/color",
+          "$ref": "#/$defs/colorReference",
           "$comment": "Shadow colour MUST conform to CSS <color> values and map to CGColor / Android colour integers."
         }
       },
@@ -1059,7 +1068,7 @@
                   }
                 ]
               },
-              "color": { "$ref": "#/$defs/color" }
+              "color": { "$ref": "#/$defs/colorReference" }
             },
             "additionalProperties": false
           },
@@ -1425,11 +1434,11 @@
       ]
     },
     "motion-length": {
-      "oneOf": [{ "$ref": "#/$defs/length-dimension" }, { "$ref": "#/$defs/function" }],
+      "oneOf": [{ "$ref": "#/$defs/lengthDimensionReference" }, { "$ref": "#/$defs/function" }],
       "$comment": "MUST evaluate to a CSS <length-percentage> (css-values-4#typedef-length-percentage) or equivalent platform distance for translation and path coordinates."
     },
     "motion-angle": {
-      "oneOf": [{ "$ref": "#/$defs/angle-dimension" }, { "$ref": "#/$defs/function" }],
+      "oneOf": [{ "$ref": "#/$defs/angleDimensionReference" }, { "$ref": "#/$defs/function" }],
       "$comment": "MUST evaluate to a CSS <angle> (css-values-4#angles) compatible with Core Animation and Android rotation APIs."
     },
     "motion-translation": {
@@ -1543,15 +1552,15 @@
           "$comment": "MUST identify the rendering context defined by CSS <shadow> functions, UIKit CALayer/NSShadow properties, or Android elevation/shadow APIs (for example css.box-shadow.surface, ios.layer.surface, android.paint.shadow-layer.surface)."
         },
         "offset": {
-          "$ref": "#/$defs/length-dimension",
+          "$ref": "#/$defs/lengthDimensionReference",
           "$comment": "Vertical offset MUST conform to CSS <length> grammar and map to CALayer.shadowOffset.height, Paint#setShadowLayer dy, or View#setElevation displacement."
         },
         "blur": {
-          "$ref": "#/$defs/length-dimension",
+          "$ref": "#/$defs/lengthDimensionReference",
           "$comment": "Blur radius MUST match the <length> position in CSS <shadow> and the CALayer.shadowRadius / Paint#setShadowLayer radius semantics."
         },
         "color": {
-          "$ref": "#/$defs/color",
+          "$ref": "#/$defs/colorReference",
           "$comment": "Shadow colour MUST conform to CSS <color> values and map to CGColor / Android colour integers used for Paint#setShadowLayer or elevation overlays."
         }
       },
@@ -1592,12 +1601,7 @@
           "type": "array",
           "items": { "$ref": "#/$defs/function-parameter" }
         },
-        {
-          "type": "object",
-          "required": ["$ref"],
-          "properties": { "$ref": { "$ref": "#/$defs/pointer" } },
-          "additionalProperties": false
-        },
+        { "$ref": "#/$defs/reference" },
         {
           "type": "object",
           "not": { "required": ["$ref"] },

--- a/tests/fixtures/negative/border-ref-type/expected.error.json
+++ b/tests/fixtures/negative/border-ref-type/expected.error.json
@@ -1,0 +1,3 @@
+{
+  "message": "border color $ref #/dimension/spacing has type dimension, expected color"
+}

--- a/tests/fixtures/negative/border-ref-type/input.json
+++ b/tests/fixtures/negative/border-ref-type/input.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "color": {
+    "accent": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.2, 0.4, 0.6, 1.0]
+      }
+    }
+  },
+  "dimension": {
+    "spacing": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 4,
+        "unit": "px"
+      }
+    }
+  },
+  "border": {
+    "invalid": {
+      "$type": "border",
+      "$value": {
+        "borderType": "css.border",
+        "color": { "$ref": "#/dimension/spacing" },
+        "style": "solid",
+        "width": {
+          "dimensionType": "length",
+          "value": 2,
+          "unit": "px"
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/border-ref-type/meta.yaml
+++ b/tests/fixtures/negative/border-ref-type/meta.yaml
@@ -1,0 +1,9 @@
+name: border ref type mismatch
+description: border color $ref must point to a color token
+assertions:
+  - schema
+  - refs
+  - type-compat
+tags:
+  - border
+  - refs

--- a/tests/fixtures/negative/typography-ref-type/expected.error.json
+++ b/tests/fixtures/negative/typography-ref-type/expected.error.json
@@ -1,0 +1,3 @@
+{
+  "message": "typography fontSize $ref #/color/brand has type color, expected dimension"
+}

--- a/tests/fixtures/negative/typography-ref-type/input.json
+++ b/tests/fixtures/negative/typography-ref-type/input.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "color": {
+    "brand": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.1, 0.2, 0.3, 1.0]
+      }
+    }
+  },
+  "dimension": {
+    "body-spacing": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 0.25,
+        "unit": "px"
+      }
+    }
+  },
+  "typography": {
+    "bad": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Inter",
+        "fontSize": { "$ref": "#/color/brand" },
+        "letterSpacing": { "$ref": "#/dimension/body-spacing" },
+        "lineHeight": 1.5
+      }
+    }
+  }
+}

--- a/tests/fixtures/negative/typography-ref-type/meta.yaml
+++ b/tests/fixtures/negative/typography-ref-type/meta.yaml
@@ -1,0 +1,9 @@
+name: typography ref type mismatch
+description: typography fontSize references a color token instead of a dimension
+assertions:
+  - schema
+  - refs
+  - type-compat
+tags:
+  - typography
+  - refs

--- a/tests/fixtures/positive/nested-refs/expected.json
+++ b/tests/fixtures/positive/nested-refs/expected.json
@@ -1,0 +1,264 @@
+{
+  "border": {
+    "focus": {
+      "$type": "border",
+      "$value": {
+        "borderType": "css.border",
+        "color": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [1, 0.55, 0, 1]
+          }
+        },
+        "style": "solid",
+        "width": {
+          "$type": "dimension",
+          "$value": {
+            "dimensionType": "length",
+            "value": 2,
+            "unit": "px"
+          }
+        }
+      }
+    }
+  },
+  "color": {
+    "brand": {
+      "base": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [0, 0.36, 0.72, 1]
+        }
+      },
+      "highlight": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [1, 0.55, 0, 1]
+        }
+      }
+    },
+    "surface": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0, 0, 0, 0.2]
+      }
+    }
+  },
+  "dimension": {
+    "border": {
+      "medium": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 2,
+          "unit": "px"
+        }
+      }
+    },
+    "shadow": {
+      "blur": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 12,
+          "unit": "px"
+        }
+      },
+      "offset": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 4,
+          "unit": "px"
+        }
+      },
+      "spread": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 0,
+          "unit": "px"
+        }
+      }
+    },
+    "typography": {
+      "body-letter-spacing": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 0.5,
+          "unit": "px"
+        }
+      },
+      "body-line-height": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 24,
+          "unit": "px"
+        }
+      },
+      "body-size": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 16,
+          "unit": "px"
+        }
+      }
+    }
+  },
+  "elevation": {
+    "raised": {
+      "$type": "elevation",
+      "$value": {
+        "blur": {
+          "$type": "dimension",
+          "$value": {
+            "dimensionType": "length",
+            "value": 12,
+            "unit": "px"
+          }
+        },
+        "color": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [0, 0, 0, 0.2]
+          }
+        },
+        "elevationType": "css.box-shadow.surface",
+        "offset": {
+          "$type": "dimension",
+          "$value": {
+            "dimensionType": "length",
+            "value": 4,
+            "unit": "px"
+          }
+        }
+      }
+    }
+  },
+  "gradient": {
+    "hero": {
+      "$type": "gradient",
+      "$value": {
+        "gradientType": "linear",
+        "stops": [
+          {
+            "color": {
+              "$type": "color",
+              "$value": {
+                "colorSpace": "srgb",
+                "components": [0, 0.36, 0.72, 1]
+              }
+            },
+            "position": 0
+          },
+          {
+            "color": {
+              "$type": "color",
+              "$value": {
+                "colorSpace": "srgb",
+                "components": [1, 0.55, 0, 1]
+              }
+            },
+            "position": 1
+          }
+        ]
+      }
+    }
+  },
+  "shadow": {
+    "card": {
+      "$type": "shadow",
+      "$value": [
+        {
+          "blur": {
+            "$type": "dimension",
+            "$value": {
+              "dimensionType": "length",
+              "value": 12,
+              "unit": "px"
+            }
+          },
+          "color": {
+            "$type": "color",
+            "$value": {
+              "colorSpace": "srgb",
+              "components": [0, 0, 0, 0.2]
+            }
+          },
+          "offsetX": {
+            "$type": "dimension",
+            "$value": {
+              "dimensionType": "length",
+              "value": 4,
+              "unit": "px"
+            }
+          },
+          "offsetY": {
+            "$type": "dimension",
+            "$value": {
+              "dimensionType": "length",
+              "value": 4,
+              "unit": "px"
+            }
+          },
+          "shadowType": "css.box-shadow",
+          "spread": {
+            "$type": "dimension",
+            "$value": {
+              "dimensionType": "length",
+              "value": 0,
+              "unit": "px"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "typography": {
+    "body": {
+      "$type": "typography",
+      "$value": {
+        "color": {
+          "$type": "color",
+          "$value": {
+            "colorSpace": "srgb",
+            "components": [0, 0.36, 0.72, 1]
+          }
+        },
+        "fontFamily": "Inter",
+        "fontSize": {
+          "$type": "dimension",
+          "$value": {
+            "dimensionType": "length",
+            "value": 16,
+            "unit": "px"
+          }
+        },
+        "letterSpacing": {
+          "$type": "dimension",
+          "$value": {
+            "dimensionType": "length",
+            "value": 0.5,
+            "unit": "px"
+          }
+        },
+        "lineHeight": {
+          "$type": "dimension",
+          "$value": {
+            "dimensionType": "length",
+            "value": 24,
+            "unit": "px"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/nested-refs/input.json
+++ b/tests/fixtures/positive/nested-refs/input.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "border": {
+    "focus": {
+      "$type": "border",
+      "$value": {
+        "borderType": "css.border",
+        "color": { "$ref": "#/color/brand/highlight" },
+        "style": "solid",
+        "width": { "$ref": "#/dimension/border/medium" }
+      }
+    }
+  },
+  "color": {
+    "brand": {
+      "base": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [0.0, 0.36, 0.72, 1.0]
+        }
+      },
+      "highlight": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [1.0, 0.55, 0.0, 1.0]
+        }
+      }
+    },
+    "surface": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [0.0, 0.0, 0.0, 0.2]
+      }
+    }
+  },
+  "dimension": {
+    "border": {
+      "medium": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 2,
+          "unit": "px"
+        }
+      }
+    },
+    "shadow": {
+      "blur": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 12,
+          "unit": "px"
+        }
+      },
+      "offset": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 4,
+          "unit": "px"
+        }
+      },
+      "spread": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 0,
+          "unit": "px"
+        }
+      }
+    },
+    "typography": {
+      "body-letter-spacing": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 0.5,
+          "unit": "px"
+        }
+      },
+      "body-line-height": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 24,
+          "unit": "px"
+        }
+      },
+      "body-size": {
+        "$type": "dimension",
+        "$value": {
+          "dimensionType": "length",
+          "value": 16,
+          "unit": "px"
+        }
+      }
+    }
+  },
+  "elevation": {
+    "raised": {
+      "$type": "elevation",
+      "$value": {
+        "blur": { "$ref": "#/dimension/shadow/blur" },
+        "color": { "$ref": "#/color/surface" },
+        "elevationType": "css.box-shadow.surface",
+        "offset": { "$ref": "#/dimension/shadow/offset" }
+      }
+    }
+  },
+  "gradient": {
+    "hero": {
+      "$type": "gradient",
+      "$value": {
+        "gradientType": "linear",
+        "stops": [
+          { "color": { "$ref": "#/color/brand/base" }, "position": 0 },
+          { "color": { "$ref": "#/color/brand/highlight" }, "position": 1 }
+        ]
+      }
+    }
+  },
+  "shadow": {
+    "card": {
+      "$type": "shadow",
+      "$value": [
+        {
+          "blur": { "$ref": "#/dimension/shadow/blur" },
+          "color": { "$ref": "#/color/surface" },
+          "offsetX": { "$ref": "#/dimension/shadow/offset" },
+          "offsetY": { "$ref": "#/dimension/shadow/offset" },
+          "shadowType": "css.box-shadow",
+          "spread": { "$ref": "#/dimension/shadow/spread" }
+        }
+      ]
+    }
+  },
+  "typography": {
+    "body": {
+      "$type": "typography",
+      "$value": {
+        "color": { "$ref": "#/color/brand/base" },
+        "fontFamily": "Inter",
+        "fontSize": { "$ref": "#/dimension/typography/body-size" },
+        "letterSpacing": { "$ref": "#/dimension/typography/body-letter-spacing" },
+        "lineHeight": { "$ref": "#/dimension/typography/body-line-height" }
+      }
+    }
+  }
+}

--- a/tests/fixtures/positive/nested-refs/meta.yaml
+++ b/tests/fixtures/positive/nested-refs/meta.yaml
@@ -1,0 +1,11 @@
+name: nested refs
+description: composite tokens using shared color and dimension tokens through $ref
+assertions:
+  - schema
+  - refs
+  - type-compat
+  - roundtrip
+  - ordering
+tags:
+  - refs
+  - composite


### PR DESCRIPTION
## Summary
- add shared reference definitions to the core schema and allow borders, shadows, gradients, elevation, and typography to accept referenced colors and dimensions
- extend validator logic and fixtures to cover nested $ref usage and type mismatches
- document alias-preserving migrations and update DTCG migration examples to reuse shared tokens

## Testing
- npm run format
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda3af5e008328bf5ab02b1b65b25e