### PR TITLE
Update parser documentation references and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Browse the deployed documentation at **[dtif.lapidist.net](https://dtif.lapidist
 
 - [Specification](https://dtif.lapidist.net/spec/) – normative chapters covering the format, token types, and conformance rules.
 - [Guides](https://dtif.lapidist.net/guides/) – implementation playbooks and tooling workflows.
+- [Using the DTIF parser](https://dtif.lapidist.net/guides/dtif-parser/) – configure the canonical parser, CLI, and plugin system.
 - [Examples](https://dtif.lapidist.net/examples/) – schema-valid token documents you can reuse in tests.
 - [Governance](https://dtif.lapidist.net/governance/) – processes for proposing changes and managing the registry.
 - [Roadmap](https://dtif.lapidist.net/roadmap/) – current focus areas and forward-looking drafts.
@@ -119,6 +120,44 @@ Browse the deployed documentation at **[dtif.lapidist.net](https://dtif.lapidist
    npm test
    npm run docs:dev   # optional: preview the docs locally
    ```
+
+## Parse DTIF documents
+
+Use the canonical parser package to cache decoded documents, resolve pointers, and drive extension plugins.
+
+1. **Install the parser**
+
+   ```bash
+   npm install @lapidist/dtif-parser
+   ```
+
+2. **Create a reusable parse session**
+
+   ```ts
+   import { createSession } from '@lapidist/dtif-parser';
+
+   const session = createSession({ allowHttp: false, maxDepth: 32 });
+   const result = await session.parseDocument('tokens/base.tokens.json');
+
+   if (result.diagnostics.hasErrors()) {
+     console.error(result.diagnostics.toArray());
+   }
+
+   const resolution = result.resolver?.resolve('#/color/brand/primary');
+   if (resolution?.token) {
+     console.log(resolution.token.value);
+   }
+   ```
+
+   Sessions expose the decoded document, normalised AST, document graph, diagnostic bag, and resolver so tooling can perform repeated lookups efficiently.
+
+3. **Inspect documents from the command line**
+
+   ```bash
+   npx dtif-parse tokens/base.tokens.json --resolve "#/color/brand/primary" --format json
+   ```
+
+   Run `dtif-parse --help` to view all CLI switches. The [parser guide](https://dtif.lapidist.net/guides/dtif-parser/) covers cache configuration, loader overrides, and plugin registration in more detail.
 
 ## TypeScript support
 

--- a/parser/README.md
+++ b/parser/README.md
@@ -5,7 +5,7 @@ package provides the reference pipeline for loading, validating, normalising,
 and resolving DTIF documents while emitting structured diagnostics for tooling
 and automation workflows.
 
-> Documentation: [Canonical parser architecture](../docs/guides/canonical-parser.md)
+> Documentation: [Using the DTIF parser](https://dtif.lapidist.net/guides/dtif-parser/)
 
 ## Installation
 
@@ -40,7 +40,7 @@ The workspace publishes a `dtif-parse` binary for quick inspection and CI
 pipelines:
 
 ```bash
-dtif-parse tokens/base.tokens.json --resolve color.brand.primary
+dtif-parse tokens/base.tokens.json --resolve "#/color/brand/primary"
 ```
 
 Use `dtif-parse --help` for the full list of options and output formats.


### PR DESCRIPTION
## Summary
- fix the parser README link and CLI pointer example
- refresh the parser guide examples for cache settings, loader overrides, and plugin registration
- document parser usage and CLI entry points in the root README with a link to the parser guide

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1415b72c08328a01d204c8cd37709