### PR TITLE
chore: configure parser package for ci and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,9 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Build parser package
+        run: npm run build --workspace=@lapidist/dtif-parser
+
+      - name: Test parser package
+        run: npm test --workspace=@lapidist/dtif-parser

--- a/parser/package.json
+++ b/parser/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "clean": "rimraf dist",
-    "test": "node --import tsx --test ./tests/**/*.test.ts"
+    "test": "node --import tsx --test ./tests/**/*.test.ts",
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@lapidist/dtif-schema": "^0.1.7",


### PR DESCRIPTION
## Summary
- run the parser build and test workflows in CI so regressions are caught automatically
- add a prepack hook so the parser package is compiled before Changesets publishes it

## Testing
- npm test
- npm run build --workspace=@lapidist/dtif-parser
- npm test --workspace=@lapidist/dtif-parser

------
https://chatgpt.com/codex/tasks/task_e_68d14204d53483289565c435bcba4ca9