### PR TITLE
Correct Design Lint documentation

### DIFF
--- a/docs/guides/design-lint.md
+++ b/docs/guides/design-lint.md
@@ -1,0 +1,68 @@
+---
+title: Design Lint
+description: Lint DTIF-aware codebases with the @lapidist/design-lint CLI.
+keywords:
+  - linting
+  - design lint
+  - dtif
+outline: [2, 3]
+---
+
+# Design Lint {#design-lint}
+
+[`@lapidist/design-lint`](https://design-lint.lapidist.net) is a DTIF-native command-line
+linter. It parses token documents with the same schema guarantees as the specification
+and applies rule sets tuned for component libraries, CSS authoring, and framework-driven
+design system work.
+
+## What Design Lint validates {#what-design-lint-checks}
+
+The linter focuses on aligning source tokens with product code:
+
+- Parse DTIF documents so colour, typography, spacing, and motion tokens retain their
+  canonical structure.
+- Enforce naming conventions and token usage across React, Vue, Svelte, and other common
+  front-end stacks.
+- Surface granular diagnostics that explain why a file failed and how to resolve the
+  mismatch.
+- Offer deterministic formatter output so teams can adopt autofix workflows safely.
+
+## Get started quickly {#getting-started}
+
+Design Lint ships as an npm package that targets Node.js 22 and above. To try it
+immediately, run:
+
+```bash
+npx design-lint .
+```
+
+For long-term adoption, install it locally and scaffold a configuration file:
+
+```bash
+npm install --save-dev @lapidist/design-lint
+npx design-lint init
+```
+
+The initializer creates `designlint.config.json` so you can opt into the rule sets that
+match your stack. Lint specific directories or glob patterns once the configuration is in
+place:
+
+```bash
+npx design-lint "src/**/*"
+```
+
+Pass `--fix` when you want the CLI to apply formatter-backed fixes, and keep CI runs in
+read-only mode so pull requests fail if manual intervention is required.
+
+## Integrate with automation {#automation}
+
+Teams can build richer workflows on top of Design Lint's subcommands and caching:
+
+- `npx design-lint validate` confirms configurations and tokens parse before linting.
+- `npx design-lint tokens --out tokens.json` exports flattened DTIF tokens for follow-on
+  build steps.
+- `--watch` mode reruns linting as files change, while the `.designlintcache` directory
+  keeps feedback fast locally and in CI caches.
+
+Adopt these recipes alongside existing task runners, GitHub Actions, or other CI/CD
+providers to keep design and engineering deliverables in sync.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -10,6 +10,7 @@ These guides offer non-normative workflows and implementation advice alongside t
 
 - [Getting started](./getting-started.md#getting-started) covers validation basics.
 - [Tooling integration](./tooling.md#tooling-integration) summarises expectations for exporters, build systems, and linters.
+- [Design Lint](./design-lint.md#design-lint) explains how to lint DTIF-aware projects with the CLI.
 - [Platform guidance](./platform-guidance.md#platform-guidance) collects ecosystem-specific mapping tips.
 - [Migrating from the DTCG format](./migrating-from-dtcg.md#migrating-from-dtcg) walks through porting Design Tokens Community Group documents to DTIF.
 - [Using the DTIF parser](./dtif-parser.md#dtif-parser-guide) explains how to install, configure, and extend the canonical parser.

--- a/docs/guides/tooling.md
+++ b/docs/guides/tooling.md
@@ -34,3 +34,9 @@ when you need a preconfigured Ajv instance inside CI or build steps.
 Linting tools _SHOULD_ warn on unknown `$type` values,
 unsupported units, and deprecated tokens. Warnings
 _SHOULD NOT_ fail builds by default.
+
+[Design Lint](https://design-lint.lapidist.net) ships as an npm package
+(`@lapidist/design-lint`). It parses DTIF payloads with the
+canonical schema, enforces rule sets tailored to component libraries and CSS authoring,
+and emits deterministic diagnostics and formatter output for both local development and
+CI pipelines.

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,8 @@ sync with the standard:
 - **Registry** – approved [`$type` identifiers, extensions, and namespaces](https://github.com/bylapidist/dtif/tree/main/registry).
 - **Conformance tests** – fixtures for verifying implementations and ensuring
   [compatibility](https://github.com/bylapidist/dtif/tree/main/tests).
+- **Design Lint** – a [DTIF-native CLI](https://design-lint.lapidist.net) for linting
+  component codebases and build pipelines.
 
 Each resource is maintained alongside the specification so updates ship together and
 are easy to adopt.


### PR DESCRIPTION
## Summary
- revert the README so it no longer advertises Design Lint as a hosted service
- rewrite the Design Lint guide and related references to reflect the documented @lapidist/design-lint CLI capabilities
- update the guides overview, tooling guide, and docs homepage to accurately describe the CLI offering

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d42d7a41c48328a325b6a21e8b65c6