### PR TITLE
feat: allow DTIF objects to bypass serialization

### DIFF
--- a/.changeset/official-parse-flatten.md
+++ b/.changeset/official-parse-flatten.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/dtif-parser': minor
+---
+
+Expose the `parseTokens` helpers, metadata and resolution snapshots, diagnostic formatters, caching utilities, and a Node adapter surface for DTIF token parsing.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -117,7 +117,11 @@ export default defineConfig({
           text: 'Tooling built with DTIF',
           items: [
             { text: 'Tooling overview', link: '/tooling/' },
-            { text: 'Design Lint', link: '/tooling/design-lint' }
+            { text: 'Design Lint', link: '/tooling/design-lint' },
+            {
+              text: 'DTIF parser API reference',
+              link: '/tooling/dtif-parser-api-reference'
+            }
           ]
         }
       ],

--- a/docs/tooling/dtif-parser-api-reference.md
+++ b/docs/tooling/dtif-parser-api-reference.md
@@ -1,0 +1,328 @@
+---
+title: DTIF parser API reference
+description: End-to-end guide to the @lapidist/dtif-parser helpers, flattened token snapshots, diagnostics, caching, and supporting architecture.
+keywords:
+  - dtif
+  - parser
+  - api
+  - tokens
+  - diagnostics
+outline: [2, 3]
+---
+
+# DTIF parser API reference {#dtif-parser-api-reference}
+
+The `@lapidist/dtif-parser` package provides the canonical runtime for loading and
+resolving Design Token Interchange Format (DTIF) documents. This guide explains
+how to call the parser, flatten tokens, consume metadata and resolution
+snapshots, and work with diagnostics across both asynchronous and synchronous
+workflows. It also surveys the underlying architecture so you know where each
+piece of the pipeline lives inside the repository.
+
+## Quick start {#quick-start}
+
+Use `parseTokens` when you want flattened tokens, metadata, resolution traces,
+and normalised diagnostics in one call:
+
+```ts
+import { parseTokens } from '@lapidist/dtif-parser';
+
+const result = await parseTokens('tokens/base.tokens.json', {
+  onDiagnostic: (diagnostic) => {
+    if (diagnostic.severity === 'error') {
+      console.error(diagnostic.message);
+    }
+  }
+});
+
+console.log(result.flattened.length);
+console.log(result.metadataIndex.get('#/color/brand/primary')?.description);
+console.log(result.resolutionIndex.get('#/color/brand/primary')?.value);
+```
+
+For inline workflows—such as bundlers or design tool plugins that already hold
+an object in memory—use the synchronous variant. It never touches the filesystem
+and will throw if a loader would be required:
+
+```ts
+import { parseTokensSync } from '@lapidist/dtif-parser';
+
+const { flattened } = parseTokensSync({
+  $schema: 'https://dtif.lapidist.net/schema.json',
+  values: {
+    color: {
+      brand: { primary: { $type: 'color', $value: '#0055ff' } }
+    }
+  }
+});
+
+console.log(flattened[0]);
+```
+
+## Supported inputs {#supported-inputs}
+
+`parseTokens` accepts the same sources as `parseDocument` while adding explicit
+support for DTIF objects:
+
+| Input                                    | Description                                                                                                                                         |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `string`                                 | Interpreted as a URI or filesystem path. The default loader reads from disk and resolves relative paths.                                            |
+| `URL`                                    | Parsed with the configured document loader (HTTP, file, or custom).                                                                                 |
+| `{ contents: string; uri?: string }`     | Inline text with an optional URI for diagnostics.                                                                                                   |
+| `ArrayBuffer`, `Uint8Array`, or `Buffer` | Treated as raw bytes paired with the provided URI, if any.                                                                                          |
+| `DesignTokenInterchangeFormat` object    | Consumed without serialisation. The loader builds a synthetic `DocumentHandle` so schema validation and caching can reuse the caller-provided data. |
+
+The synchronous helper only accepts inline text or DTIF objects. It raises an
+error if resolving the input would require I/O (e.g., HTTP or disk access).
+
+## Options {#options}
+
+`ParseTokensOptions` extend the base session options with flattening, graph
+control, caching hooks, and diagnostic observers.
+
+| Option                   | Type                                    | Default     | Purpose                                                                                                                                                                     |
+| ------------------------ | --------------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flatten`                | `boolean`                               | `true`      | Skips the flattening stage when `false`, returning empty arrays for `flattened`, `metadataIndex`, and `resolutionIndex`. Useful if you only need the raw session artefacts. |
+| `includeGraphs`          | `boolean`                               | `true`      | Includes `document`, `graph`, and `resolver` on the result. Disable when you only care about the flattened outputs.                                                         |
+| `cache`                  | `ParseCache`                            | `undefined` | Stores flattened tokens, metadata, resolution snapshots, and diagnostics keyed by the document hash. The bundled `InMemoryParseCache` offers LRU eviction.                  |
+| `documentCache`          | `DocumentCache`                         | `undefined` | Shares decoded documents across sessions. Async-only: `parseTokensSync` throws if this is provided.                                                                         |
+| `onDiagnostic`           | `(diagnostic: TokenDiagnostic) => void` | `undefined` | Invoked for every diagnostic in severity order as soon as it is produced, including cache hits.                                                                             |
+| `warn`                   | `(diagnostic: TokenDiagnostic) => void` | `undefined` | Called for non-fatal warnings. Use this to surface soft failures immediately while still receiving a complete result.                                                       |
+| `...ParseSessionOptions` | —                                       | —           | Any session option (`loader`, `schemaGuard`, `plugins`, etc.) is forwarded to `createSession`.                                                                              |
+
+## Result shape {#result-shape}
+
+Both helpers return the same structure:
+
+```ts
+interface ParseTokensResult {
+  document?: RawDocument;
+  graph?: DocumentGraph;
+  resolver?: DocumentResolver;
+  flattened: readonly DtifFlattenedToken[];
+  metadataIndex: ReadonlyMap<TokenId, TokenMetadataSnapshot>;
+  resolutionIndex: ReadonlyMap<TokenId, ResolvedTokenView>;
+  diagnostics: readonly TokenDiagnostic[];
+}
+```
+
+- `document`, `graph`, and `resolver` are only present when `includeGraphs` is
+  `true` and the document parsed successfully.
+- `flattened` provides ready-to-render values, aliases, and references.
+- `metadataIndex` exposes per-token metadata for descriptions, extensions, and
+  deprecation details.
+- `resolutionIndex` mirrors the resolver cache so you can inspect resolution
+  paths, applied overrides, and reference chains.
+- `diagnostics` is always populated, even for cache hits. The array is ordered by
+  severity, then by the original emission order.
+
+### Flattened token entries {#flattened-token-entries}
+
+`DtifFlattenedToken` aligns with the DTIF schema. Each entry includes:
+
+- `id`: Stable token identifier, matching the canonical JSON pointer.
+- `pointer`: Pointer to the token’s location within the source document.
+- `type`: The declared DTIF token type.
+- `value`: Resolved JavaScript value suitable for design tooling or build
+  pipelines.
+- `raw`: The un-transformed `$value` from the source document.
+- `path`: Collection path segments that describe the hierarchy.
+- `mode`: Normalised mode value when present.
+
+### Metadata snapshots {#metadata-snapshots}
+
+`createMetadataSnapshot(session, graph)` builds the `metadataIndex` map and is
+exported for advanced use cases. Metadata entries are cloned to plain JSON and
+contain:
+
+- `description`: Normalised description text when present.
+- `extensions`: Deep-cloned extension records.
+- `deprecated`: Optional object describing deprecation reasons and replacement
+  pointers.
+- `source`: `{ uri, line, column }` pointing to the token definition for
+  diagnostics and editor integrations.
+
+### Resolution views {#resolution-views}
+
+`createResolutionSnapshot(resolver)` powers `resolutionIndex`. Each entry tracks:
+
+- `id`, `type`, and `raw` schema-level information.
+- `value`: The resolved token value, post-aliasing and overrides.
+- `references`: Immediate references encountered while resolving the token.
+- `resolutionPath`: The ordered chain of pointers the resolver followed.
+- `appliedAliases`: Alias tokens that were ultimately applied.
+
+## Diagnostics {#diagnostics}
+
+All diagnostics emitted by the loader, schema guard, normaliser, and resolver are
+normalised via `toTokenDiagnostic`. The resulting `TokenDiagnostic` interface is
+compatible with Language Server Protocol conventions and includes related
+information with URI-anchored ranges. Format diagnostics for terminal output or
+logging with `formatTokenDiagnostic`:
+
+```ts
+import { parseTokens, formatTokenDiagnostic } from '@lapidist/dtif-parser';
+
+const { diagnostics } = await parseTokens('tokens/base.tokens.json');
+
+for (const diagnostic of diagnostics) {
+  console.log(formatTokenDiagnostic(diagnostic, { color: process.stdout.isTTY }));
+}
+```
+
+`parseTokens` invokes `onDiagnostic` and `warn` hooks immediately so tooling can
+stream feedback while the document is processed. Cached results re-emit the saved
+warnings before returning.
+
+## Caching {#caching}
+
+The parser separates document caching from flattening caches:
+
+- `documentCache` (a `DocumentCache` implementation) deduplicates decoded raw
+  documents and schema results across sessions. This mirrors the behaviour
+  already available through `createSession`.
+- `cache` (a `ParseCache`) stores flattened outputs keyed by the document hash.
+  Use `InMemoryParseCache` for a drop-in LRU cache:
+
+```ts
+import { parseTokens, InMemoryParseCache } from '@lapidist/dtif-parser';
+
+const cache = new InMemoryParseCache({ maxEntries: 50 });
+await parseTokens('tokens/base.tokens.json', { cache }); // parses and caches
+await parseTokens('tokens/base.tokens.json', { cache }); // served from cache
+```
+
+`createParseCache` exports the same implementation with configuration defaults.
+Provide your own cache by implementing `get` and `set` if you need persistence or
+shared storage.
+
+## Sessions and document loaders {#sessions-and-document-loaders}
+
+When you need to customise document loading, plugin resolution, or parse
+multiple documents with shared state, create a session manually:
+
+```ts
+import { createSession } from '@lapidist/dtif-parser';
+
+const session = createSession({
+  loader: new DefaultDocumentLoader({ fetch }),
+  plugins: createPluginRegistry().use(/* … */)
+});
+
+const result = await session.parseDocument('tokens/base.tokens.json');
+```
+
+Sessions use the same zero-serialisation path as `parseTokens`. When you pass a
+DTIF object, the loader constructs an in-memory `DocumentHandle` so schema
+validation, graph building, and caching reuse the caller-provided data without a
+stringify/parse round trip.
+
+## Node adapter {#node-adapter}
+
+The Node adapter wraps the helper in filesystem-friendly ergonomics:
+
+```ts
+import { parseTokensFromFile } from '@lapidist/dtif-parser/adapters/node';
+
+try {
+  const result = await parseTokensFromFile('tokens/base.tokens.json', {
+    cwd: process.cwd(),
+    onDiagnostic: (d) => console.log(d.message)
+  });
+  console.log(result.flattened.length);
+} catch (error) {
+  if (error instanceof DtifTokenParseError) {
+    for (const diagnostic of error.diagnostics) {
+      console.error(formatTokenDiagnostic(diagnostic));
+    }
+  }
+}
+```
+
+- Validates file extensions against the `.tokens.json` convention.
+- Normalises diagnostics to `TokenDiagnostic` values and exposes them on
+  `DtifTokenParseError`.
+- Populates the same flattened token and snapshot structures returned by
+  `parseTokens`.
+- Provides `readTokensFile` when you only need the decoded DTIF document.
+
+## Package architecture {#package-architecture}
+
+Understanding how the codebase fits together makes it easier to extend the API
+without breaking existing workflows.
+
+### Public entry points {#public-entry-points}
+
+The package exposes all user-facing APIs from the main index module:
+
+- [`src/index.ts`](https://github.com/bylapidist/dtif/blob/main/parser/src/index.ts)
+  re-exports factories and utilities including `createSession`, `parseDocument`,
+  resolver helpers, graph traversal utilities, diagnostic primitives, and the
+  token helpers documented above.
+- [`src/session.ts`](https://github.com/bylapidist/dtif/blob/main/parser/src/session.ts)
+  defines the `ParseSession` class and the `createSession` factory. Sessions
+  orchestrate document loading, caching, schema validation, AST normalisation,
+  graph construction, and resolver initialisation for each parse request.
+
+### Session lifecycle {#session-lifecycle}
+
+`ParseSession.parseDocument` executes the pipeline below:
+
+1. Use the configured document loader to convert caller input into a
+   `DocumentHandle`, surfacing loader diagnostics on failure.
+2. Resolve cached `RawDocument` instances before decoding handles via
+   `decodeDocument`, again collecting diagnostics when decoding fails.
+3. Validate the JSON schema through `SchemaGuard`, returning early when the
+   document is invalid while still exposing decoded bytes to the caller.
+4. Normalise the AST and build the directed token graph, feeding diagnostics back
+   into the shared `DiagnosticBag`.
+5. Instantiate a `DocumentResolver` that supports alias resolution, overrides,
+   and plugin transforms whenever a graph is available.
+
+The `parseTokens` helper reuses these seams so it can share infrastructure with
+existing session workflows while layering flattened outputs and metadata
+snapshots on top.
+
+### Graph and resolver utilities {#graph-and-resolver-utilities}
+
+Supporting modules wire the AST into usable graph and resolver structures:
+
+- [`src/graph/builder.ts`](https://github.com/bylapidist/dtif/blob/main/parser/src/graph/builder.ts)
+  generates a `DocumentGraph` from the normalised AST and emits structural
+  diagnostics when relationships cannot be resolved.
+- [`src/resolver/document-resolver.ts`](https://github.com/bylapidist/dtif/blob/main/parser/src/resolver/document-resolver.ts)
+  implements the resolution engine. It tracks visited pointers, enforces the
+  `maxDepth` guard, records override applications, and exposes `ResolvedToken`
+  instances for downstream tooling. The resolver already caches intermediate
+  resolution state that snapshot helpers reuse.
+
+### Diagnostics and supporting types {#diagnostics-and-supporting-types}
+
+Diagnostic primitives keep feedback consistent across the loader, normaliser,
+and resolver:
+
+- [`src/diagnostics/bag.ts`](https://github.com/bylapidist/dtif/blob/main/parser/src/diagnostics/bag.ts)
+  collects parser, loader, and resolver diagnostics in a stable insertion order
+  while offering convenience helpers such as `hasErrors` and severity counters.
+- [`src/diagnostics/codes.ts`](https://github.com/bylapidist/dtif/blob/main/parser/src/diagnostics/codes.ts)
+  and [`src/diagnostics/severity.ts`](https://github.com/bylapidist/dtif/blob/main/parser/src/diagnostics/severity.ts)
+  define the severity taxonomy and stable diagnostic codes that map onto the new
+  `TokenDiagnostic` shape.
+- [`src/types.ts`](https://github.com/bylapidist/dtif/blob/main/parser/src/types.ts)
+  centralises shared type definitions including `ParseInput`, `ParseResult`,
+  `DocumentGraph`, and the diagnostic model.
+
+### Testing conventions {#testing-conventions}
+
+Tests live alongside the source under `parser/tests` and are split by scope:
+
+- Unit suites in [`tests/unit`](https://github.com/bylapidist/dtif/tree/main/parser/tests/unit)
+  exercise isolated components such as session caching, resolver alias chains,
+  snapshot builders, and diagnostic helpers.
+- Integration suites in [`tests/integration`](https://github.com/bylapidist/dtif/tree/main/parser/tests/integration)
+  cover multi-file parsing, end-to-end `parseTokens` usage—including cache reuse
+  and synchronous inputs—plus the Node adapter surface.
+
+Keeping this reference close to the rest of the documentation ensures ongoing
+roadmap work builds on a shared understanding of both the public API and the
+parser internals.

--- a/docs/tooling/index.md
+++ b/docs/tooling/index.md
@@ -14,6 +14,12 @@ aligned across platforms.
 - [Design Lint](./design-lint.md#design-lint) – lint component libraries and build
   pipelines with a DTIF-native command-line interface.
 
+## Parser internals {#parser-internals}
+
+- [DTIF parser API reference](./dtif-parser-api-reference.md#dtif-parser-api-reference)
+  – survey the `@lapidist/dtif-parser` entry points, session lifecycle, and tests before
+  landing roadmap work.
+
 ## Contribute new tooling {#contribute-tooling}
 
 Have you built a DTIF integration, exporter, or quality gate? Open a pull request to add

--- a/parser/package.json
+++ b/parser/package.json
@@ -15,6 +15,14 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./parse-tokens": {
+      "types": "./dist/tokens/parse-tokens.d.ts",
+      "import": "./dist/tokens/parse-tokens.js"
+    },
+    "./adapters/node": {
+      "types": "./dist/adapters/node/index.d.ts",
+      "import": "./dist/adapters/node/index.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/parser/src/adapters/node/index.ts
+++ b/parser/src/adapters/node/index.ts
@@ -1,0 +1,2 @@
+export { parseTokensFromFile, readTokensFile, DtifTokenParseError } from './token-parser.js';
+export type { NodeParseTokensOptions } from './token-parser.js';

--- a/parser/src/adapters/node/token-parser.ts
+++ b/parser/src/adapters/node/token-parser.ts
@@ -1,0 +1,124 @@
+import type { DesignTokenInterchangeFormat } from '@lapidist/dtif-schema';
+
+import { parseTokens } from '../../tokens/parse-tokens.js';
+import type { ParseTokensOptions, ParseTokensResult } from '../../tokens/parse-tokens.js';
+import { formatTokenDiagnostic } from '../../tokens/diagnostics.js';
+import type { FormatTokenDiagnosticOptions, TokenDiagnostic } from '../../tokens/types.js';
+
+const SUPPORTED_EXTENSIONS = ['.tokens', '.tokens.json', '.tokens.yaml', '.tokens.yml'];
+
+export interface NodeParseTokensOptions extends ParseTokensOptions {
+  readonly onWarn?: (message: string) => void;
+  readonly diagnosticFormat?: FormatTokenDiagnosticOptions;
+}
+
+export class DtifTokenParseError extends Error {
+  readonly diagnostics: readonly TokenDiagnostic[];
+  readonly source: string;
+  readonly formatOptions?: FormatTokenDiagnosticOptions;
+
+  constructor(
+    source: string | URL,
+    diagnostics: readonly TokenDiagnostic[],
+    formatOptions?: FormatTokenDiagnosticOptions
+  ) {
+    const sourceText = toSourceString(source);
+    super(createDtifErrorMessage(sourceText, diagnostics, formatOptions));
+    this.name = 'DtifTokenParseError';
+    this.diagnostics = diagnostics;
+    this.source = sourceText;
+    this.formatOptions = formatOptions;
+  }
+
+  format(options?: FormatTokenDiagnosticOptions): string {
+    return createDtifErrorMessage(this.source, this.diagnostics, options ?? this.formatOptions);
+  }
+}
+
+export async function parseTokensFromFile(
+  filePath: string | URL,
+  options: NodeParseTokensOptions = {}
+): Promise<ParseTokensResult> {
+  assertSupportedFile(filePath);
+  const parseOptions = toParseTokensOptions(options);
+  const result = await parseTokens(filePath, parseOptions);
+  const errors = result.diagnostics.filter((diagnostic) => diagnostic.severity === 'error');
+  if (errors.length > 0) {
+    throw new DtifTokenParseError(filePath, errors, options.diagnosticFormat);
+  }
+  return result;
+}
+
+export async function readTokensFile(
+  filePath: string | URL,
+  options: NodeParseTokensOptions = {}
+): Promise<DesignTokenInterchangeFormat> {
+  const result = await parseTokensFromFile(filePath, options);
+  const document = result.document;
+  if (!document) {
+    throw new Error(`DTIF parser did not return a document for ${toSourceString(filePath)}`);
+  }
+  const data = document.data;
+  assertIsDesignTokenDocument(data, document.uri.href);
+  return data;
+}
+
+function toParseTokensOptions(options: NodeParseTokensOptions): ParseTokensOptions {
+  const { onWarn, diagnosticFormat, ...rest } = options;
+  if (!onWarn) {
+    return rest;
+  }
+
+  const originalWarn = rest.warn;
+
+  return {
+    ...rest,
+    warn: (diagnostic) => {
+      if (diagnostic.severity === 'error') {
+        return;
+      }
+      onWarn(formatTokenDiagnostic(diagnostic, diagnosticFormat));
+      originalWarn?.(diagnostic);
+    }
+  } satisfies ParseTokensOptions;
+}
+
+function assertSupportedFile(filePath: string | URL): void {
+  const source = toSourceString(filePath);
+  if (!SUPPORTED_EXTENSIONS.some((extension) => source.endsWith(extension))) {
+    throw new Error(`Unsupported design tokens file: ${source}`);
+  }
+}
+
+function createDtifErrorMessage(
+  source: string,
+  diagnostics: readonly TokenDiagnostic[],
+  formatOptions?: FormatTokenDiagnosticOptions
+): string {
+  const header = `Failed to parse DTIF document: ${source}`;
+  const formatted = diagnostics.map((diagnostic) =>
+    formatTokenDiagnostic(diagnostic, formatOptions)
+  );
+  return [header, ...formatted.map((line) => `  - ${line}`)].join('\n');
+}
+
+function toSourceString(source: string | URL): string {
+  return typeof source === 'string' ? source : source.toString();
+}
+
+function assertIsDesignTokenDocument(
+  value: unknown,
+  source: string
+): asserts value is DesignTokenInterchangeFormat {
+  if (!isDesignTokenDocument(value)) {
+    throw new Error(`DTIF parser returned unexpected document contents for ${source}`);
+  }
+}
+
+function isDesignTokenDocument(value: unknown): value is DesignTokenInterchangeFormat {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/parser/src/index.ts
+++ b/parser/src/index.ts
@@ -83,6 +83,7 @@ export type {
   ParseCollectionResult,
   ParseInput,
   ParseInputRecord,
+  ParseDataInputRecord,
   ParseResult,
   RawDocument,
   RelatedInformation,
@@ -136,3 +137,38 @@ export type {
   ResolvedTokenTransformResult,
   ResolvedTokenTransformEvaluation
 } from './plugins/index.js';
+
+export { toTokenDiagnostic, formatTokenDiagnostic } from './tokens/diagnostics.js';
+export type {
+  FormatTokenDiagnosticOptions,
+  TokenDiagnostic,
+  TokenDiagnosticContext,
+  TokenId,
+  TokenPointer,
+  TokenMetadataSnapshot,
+  ResolvedTokenView,
+  TokenType,
+  JsonValue,
+  DtifFlattenedToken
+} from './tokens/types.js';
+export { parseTokens, parseTokensSync } from './tokens/parse-tokens.js';
+export type {
+  ParseTokensInput,
+  ParseTokensOptions,
+  ParseTokensResult
+} from './tokens/parse-tokens.js';
+export { createMetadataSnapshot, createResolutionSnapshot } from './tokens/snapshots.js';
+export { flattenTokens } from './tokens/flatten.js';
+export { InMemoryParseCache, createParseCache } from './tokens/cache.js';
+export type {
+  ParseCache,
+  ParseCacheEntry,
+  ParseCacheKey,
+  InMemoryParseCacheOptions
+} from './tokens/cache.js';
+export {
+  parseTokensFromFile,
+  readTokensFile,
+  DtifTokenParseError
+} from './adapters/node/token-parser.js';
+export type { NodeParseTokensOptions } from './adapters/node/token-parser.js';

--- a/parser/src/io/decoder.ts
+++ b/parser/src/io/decoder.ts
@@ -2,10 +2,16 @@ import type { DocumentHandle, RawDocument } from '../types.js';
 import { decodeBytes } from './decoder/encoding.js';
 import { buildSourceMap } from './decoder/source-map.js';
 import { parseYaml, toJavaScript } from './decoder/yaml.js';
+import { cloneJsonValue } from '../utils/clone-json.js';
+import { createSyntheticSourceMap } from './decoder/synthetic-source-map.js';
 
 export { DecoderError } from './decoder/errors.js';
 
 export async function decodeDocument(handle: DocumentHandle): Promise<RawDocument> {
+  if (handle.data !== undefined) {
+    return Object.freeze(createRawDocumentFromProvidedData(handle));
+  }
+
   const { text } = decodeBytes(handle.bytes);
   const { document: yamlDocument, lineCounter } = parseYaml(text);
   const data = toJavaScript(yamlDocument);
@@ -19,4 +25,35 @@ export async function decodeDocument(handle: DocumentHandle): Promise<RawDocumen
     data,
     sourceMap
   });
+}
+
+function createRawDocumentFromProvidedData(handle: DocumentHandle): RawDocument {
+  const data = cloneJsonValue(handle.data!);
+
+  if (typeof handle.text === 'string' && handle.text.length > 0) {
+    const text = handle.text;
+    const { document: yamlDocument, lineCounter } = parseYaml(text);
+    const sourceMap = buildSourceMap(handle, text, yamlDocument.contents, lineCounter);
+
+    return {
+      uri: handle.uri,
+      contentType: handle.contentType,
+      bytes: handle.bytes,
+      text,
+      data,
+      sourceMap
+    } satisfies RawDocument;
+  }
+
+  const text = handle.text ?? '';
+  const sourceMap = createSyntheticSourceMap(handle.uri, data);
+
+  return {
+    uri: handle.uri,
+    contentType: handle.contentType,
+    bytes: handle.bytes,
+    text,
+    data,
+    sourceMap
+  } satisfies RawDocument;
 }

--- a/parser/src/io/decoder/synthetic-source-map.ts
+++ b/parser/src/io/decoder/synthetic-source-map.ts
@@ -1,0 +1,42 @@
+import { JSON_POINTER_ROOT, appendJsonPointer } from '../../utils/json-pointer.js';
+import { createSourceSpan, ZERO_SOURCE_POSITION } from '../../utils/source.js';
+import type { JsonPointer, SourceMap, SourceSpan } from '../../types.js';
+
+export function createSyntheticSourceMap(uri: URL, value: unknown): SourceMap {
+  const pointers = new Map<JsonPointer, SourceSpan>();
+  const span = createSourceSpan(uri, ZERO_SOURCE_POSITION, ZERO_SOURCE_POSITION);
+  pointers.set(JSON_POINTER_ROOT, span);
+  populatePointers(value, JSON_POINTER_ROOT, pointers, uri);
+  return Object.freeze({ uri, pointers });
+}
+
+function populatePointers(
+  value: unknown,
+  pointer: JsonPointer,
+  pointers: Map<JsonPointer, SourceSpan>,
+  uri: URL
+): void {
+  if (value === null || value === undefined) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => {
+      const childPointer = appendJsonPointer(pointer, String(index)) as JsonPointer;
+      pointers.set(childPointer, createSourceSpan(uri, ZERO_SOURCE_POSITION, ZERO_SOURCE_POSITION));
+      populatePointers(item, childPointer, pointers, uri);
+    });
+    return;
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+      a.localeCompare(b)
+    );
+    for (const [key, childValue] of entries) {
+      const childPointer = appendJsonPointer(pointer, key) as JsonPointer;
+      pointers.set(childPointer, createSourceSpan(uri, ZERO_SOURCE_POSITION, ZERO_SOURCE_POSITION));
+      populatePointers(childValue, childPointer, pointers, uri);
+    }
+  }
+}

--- a/parser/src/tokens/cache.ts
+++ b/parser/src/tokens/cache.ts
@@ -1,0 +1,155 @@
+import { createHash } from 'node:crypto';
+
+import type { ResolvedParseSessionOptions } from '../session/internal/options.js';
+import type {
+  DtifFlattenedToken,
+  ResolvedTokenView,
+  TokenDiagnostic,
+  TokenId,
+  TokenMetadataSnapshot
+} from './types.js';
+import type { RawDocument } from '../types.js';
+import { hashJsonValue } from '../utils/hash-json.js';
+
+export interface ParseCacheKey {
+  readonly uri: string;
+  readonly variant: string;
+}
+
+export interface ParseCacheEntry {
+  readonly documentHash: string;
+  readonly flattened?: readonly DtifFlattenedToken[];
+  readonly metadataIndex?: ReadonlyMap<TokenId, TokenMetadataSnapshot>;
+  readonly resolutionIndex?: ReadonlyMap<TokenId, ResolvedTokenView>;
+  readonly diagnostics?: readonly TokenDiagnostic[];
+  readonly timestamp: number;
+}
+
+export interface ParseCache {
+  get(key: ParseCacheKey): ParseCacheEntry | undefined | Promise<ParseCacheEntry | undefined>;
+  set(key: ParseCacheKey, value: ParseCacheEntry): void | Promise<void>;
+}
+
+export interface InMemoryParseCacheOptions {
+  readonly maxEntries?: number;
+  readonly ttlMs?: number;
+}
+
+const DEFAULT_MAX_ENTRIES = 100;
+
+export class InMemoryParseCache implements ParseCache {
+  readonly #maxEntries: number;
+  readonly #ttlMs?: number;
+  readonly #store = new Map<
+    string,
+    { readonly entry: ParseCacheEntry; readonly createdAt: number }
+  >();
+
+  constructor(options: InMemoryParseCacheOptions = {}) {
+    this.#maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.#ttlMs = options.ttlMs;
+  }
+
+  get(key: ParseCacheKey): ParseCacheEntry | undefined {
+    const id = serializeKey(key);
+    const stored = this.#store.get(id);
+    if (!stored) {
+      return undefined;
+    }
+
+    if (this.#ttlMs && Date.now() - stored.createdAt > this.#ttlMs) {
+      this.#store.delete(id);
+      return undefined;
+    }
+
+    // refresh LRU ordering
+    this.#store.delete(id);
+    this.#store.set(id, { entry: stored.entry, createdAt: stored.createdAt });
+    return stored.entry;
+  }
+
+  set(key: ParseCacheKey, value: ParseCacheEntry): void {
+    const id = serializeKey(key);
+    this.#store.delete(id);
+    this.#store.set(id, { entry: value, createdAt: Date.now() });
+    this.#evict();
+  }
+
+  #evict(): void {
+    if (this.#store.size <= this.#maxEntries) {
+      return;
+    }
+
+    const iterator = this.#store.keys();
+    while (this.#store.size > this.#maxEntries) {
+      const next = iterator.next();
+      if (next.done) {
+        break;
+      }
+      this.#store.delete(next.value);
+    }
+  }
+}
+
+export function createParseCache(options?: InMemoryParseCacheOptions): InMemoryParseCache {
+  return new InMemoryParseCache(options);
+}
+
+export function computeDocumentHash(input: Uint8Array | RawDocument): string {
+  if (input instanceof Uint8Array) {
+    return createHash('sha256').update(input).digest('hex');
+  }
+
+  if (input.data !== undefined) {
+    return hashJsonValue(input.data, { algorithm: 'sha256' });
+  }
+
+  return createHash('sha256').update(input.bytes).digest('hex');
+}
+
+export function createCacheKey(uri: string, options: ResolvedParseSessionOptions): ParseCacheKey {
+  return {
+    uri,
+    variant: createOptionsVariant(options)
+  } satisfies ParseCacheKey;
+}
+
+function createOptionsVariant(options: ResolvedParseSessionOptions): string {
+  const payload = {
+    maxDepth: options.maxDepth,
+    context: normalizeContext(options.overrideContext),
+    plugins: normalizePlugins(options.plugins)
+  } satisfies Record<string, unknown>;
+
+  return createHash('sha1').update(JSON.stringify(payload)).digest('hex');
+}
+
+function normalizeContext(
+  context: ResolvedParseSessionOptions['overrideContext']
+): Record<string, unknown> | undefined {
+  if (!context) {
+    return undefined;
+  }
+
+  const entries = Array.from(context.entries()).sort(([a], [b]) => a.localeCompare(b));
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of entries) {
+    normalized[key] = value;
+  }
+  return normalized;
+}
+
+function normalizePlugins(
+  plugins: ResolvedParseSessionOptions['plugins']
+): readonly string[] | undefined {
+  if (!plugins) {
+    return undefined;
+  }
+
+  const transformCount = plugins.transforms.length;
+  return [`transforms:${transformCount}`];
+}
+
+function serializeKey(key: ParseCacheKey): string {
+  return `${key.uri}::${key.variant}`;
+}

--- a/parser/src/tokens/diagnostics.ts
+++ b/parser/src/tokens/diagnostics.ts
@@ -1,0 +1,160 @@
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { Diagnostic, JsonPointer, RelatedInformation, SourceSpan } from '../types.js';
+import { normalizeJsonPointer } from '../utils/json-pointer.js';
+import {
+  type FormatTokenDiagnosticOptions,
+  type Range,
+  type TokenDiagnostic,
+  type TokenDiagnosticContext
+} from './types.js';
+
+const DEFAULT_URI = 'unknown://dtif-token';
+
+export function toTokenDiagnostic(
+  diagnostic: Diagnostic,
+  context: TokenDiagnosticContext = {}
+): TokenDiagnostic {
+  const span = resolveSpan(diagnostic.span, diagnostic.pointer, context);
+  const targetUri = span?.uri?.href ?? context.documentUri ?? DEFAULT_URI;
+  const targetRange = span ? toRange(span) : createZeroRange();
+
+  return {
+    severity: diagnostic.severity,
+    code: String(diagnostic.code),
+    message: diagnostic.message,
+    source: 'dtif-parser',
+    target: {
+      uri: targetUri,
+      range: targetRange
+    },
+    related: mapRelated(diagnostic.related, context)
+  };
+}
+
+export function formatTokenDiagnostic(
+  diagnostic: TokenDiagnostic,
+  options: FormatTokenDiagnosticOptions = {}
+): string {
+  const colorize = options.color ? selectColorizer(diagnostic.severity) : passthrough;
+  const severityLabel = diagnostic.severity.toUpperCase();
+  const header = `${colorize(severityLabel)} ${diagnostic.code}: ${diagnostic.message}`;
+  const location = formatTarget(diagnostic.target, options.cwd);
+  const lines = [header, `  at ${location}`];
+
+  if (diagnostic.related && diagnostic.related.length > 0) {
+    for (const related of diagnostic.related) {
+      lines.push(`  related: ${related.message}`);
+      lines.push(`    at ${formatTarget(related.target, options.cwd)}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function resolveSpan(
+  span: SourceSpan | undefined,
+  pointer: JsonPointer | undefined,
+  context: TokenDiagnosticContext
+): SourceSpan | undefined {
+  if (span) {
+    return span;
+  }
+
+  if (!pointer || !context.pointerSpans) {
+    return undefined;
+  }
+
+  const normalized = normalizeJsonPointer(pointer);
+  return context.pointerSpans.get(normalized);
+}
+
+function toRange(span: SourceSpan): Range {
+  return {
+    start: toPosition(span.start),
+    end: toPosition(span.end)
+  };
+}
+
+function toPosition(position: SourceSpan['start']): { line: number; character: number } {
+  const line = Number.isFinite(position.line) ? position.line - 1 : 0;
+  const column = Number.isFinite(position.column) ? position.column - 1 : 0;
+  return {
+    line: line >= 0 ? line : 0,
+    character: column >= 0 ? column : 0
+  };
+}
+
+function createZeroRange(): Range {
+  return {
+    start: { line: 0, character: 0 },
+    end: { line: 0, character: 0 }
+  };
+}
+
+function mapRelated(
+  related: readonly RelatedInformation[] | undefined,
+  context: TokenDiagnosticContext
+): TokenDiagnostic['related'] {
+  if (!related || related.length === 0) {
+    return undefined;
+  }
+
+  const entries: NonNullable<TokenDiagnostic['related']> = [];
+
+  for (const item of related) {
+    const span = resolveSpan(item.span, item.pointer, context);
+    const uri = span?.uri?.href ?? context.documentUri ?? DEFAULT_URI;
+    entries.push({
+      message: item.message,
+      target: {
+        uri,
+        range: span ? toRange(span) : createZeroRange()
+      }
+    });
+  }
+
+  return entries;
+}
+
+function selectColorizer(severity: TokenDiagnostic['severity']): (value: string) => string {
+  switch (severity) {
+    case 'error':
+      return (value) => `\u001b[31m${value}\u001b[0m`;
+    case 'warning':
+      return (value) => `\u001b[33m${value}\u001b[0m`;
+    case 'info':
+    default:
+      return (value) => `\u001b[36m${value}\u001b[0m`;
+  }
+}
+
+function passthrough(value: string): string {
+  return value;
+}
+
+function formatTarget(target: TokenDiagnostic['target'], cwd: string | undefined): string {
+  const { uri, range } = target;
+  const location = formatUri(uri, cwd);
+  const line = range.start.line + 1;
+  const character = range.start.character + 1;
+  return `${location}:${line}:${character}`;
+}
+
+function formatUri(uri: string, cwd: string | undefined): string {
+  try {
+    const parsed = new URL(uri);
+    if (parsed.protocol === 'file:') {
+      const filePath = fileURLToPath(parsed);
+      if (cwd) {
+        const relative = path.relative(cwd, filePath);
+        return relative.startsWith('..') ? filePath : relative || '.';
+      }
+      return filePath;
+    }
+    return parsed.href;
+  } catch {
+    return uri;
+  }
+}

--- a/parser/src/tokens/flatten.ts
+++ b/parser/src/tokens/flatten.ts
@@ -1,0 +1,33 @@
+import type { DocumentGraph } from '../graph/nodes.js';
+import { getBaseType, getBaseValue, getTokenId, iterateTokenNodes } from './internal/graph.js';
+import { toPlainJson } from './internal/utils.js';
+import type { DtifFlattenedToken, ResolvedTokenView, TokenId } from './types.js';
+
+export function flattenTokens(
+  graph: DocumentGraph,
+  resolutionIndex: ReadonlyMap<TokenId, ResolvedTokenView>
+): DtifFlattenedToken[] {
+  const nodes = Array.from(iterateTokenNodes(graph));
+  nodes.sort((left, right) => left.pointer.localeCompare(right.pointer));
+
+  const flattened: DtifFlattenedToken[] = [];
+
+  for (const node of nodes) {
+    const id = getTokenId(node.pointer);
+    const resolution = resolutionIndex.get(id);
+    const baseType = getBaseType(node);
+    const baseValue = toPlainJson(getBaseValue(node));
+
+    flattened.push({
+      id,
+      pointer: id,
+      name: node.name,
+      path: node.path,
+      type: resolution?.type ?? baseType,
+      value: resolution?.value ?? baseValue,
+      raw: baseValue
+    });
+  }
+
+  return flattened;
+}

--- a/parser/src/tokens/internal/graph.ts
+++ b/parser/src/tokens/internal/graph.ts
@@ -1,0 +1,42 @@
+import { normalizeJsonPointer } from '../../utils/json-pointer.js';
+import type {
+  DocumentGraph,
+  GraphAliasNode,
+  GraphNode,
+  GraphTokenNode
+} from '../../graph/nodes.js';
+import type { TokenId } from '../types.js';
+
+export function isTokenLikeNode(node: GraphNode): node is GraphTokenNode | GraphAliasNode {
+  return node.kind === 'token' || node.kind === 'alias';
+}
+
+export function iterateTokenNodes(
+  graph: DocumentGraph
+): IterableIterator<GraphTokenNode | GraphAliasNode> {
+  return (function* () {
+    for (const node of graph.nodes.values()) {
+      if (isTokenLikeNode(node)) {
+        yield node;
+      }
+    }
+  })();
+}
+
+export function getTokenId(pointer: string): TokenId {
+  return normalizeJsonPointer(pointer) as TokenId;
+}
+
+export function getBaseType(node: GraphTokenNode | GraphAliasNode): string | undefined {
+  if (node.kind === 'alias') {
+    return node.type.value;
+  }
+  return node.type?.value;
+}
+
+export function getBaseValue(node: GraphTokenNode | GraphAliasNode): unknown {
+  if (node.kind === 'alias') {
+    return undefined;
+  }
+  return node.value?.value;
+}

--- a/parser/src/tokens/internal/utils.ts
+++ b/parser/src/tokens/internal/utils.ts
@@ -1,0 +1,60 @@
+import type { JsonValue, TokenPointer } from '../types.js';
+
+export function toPlainJson(value: unknown): JsonValue | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'boolean' ||
+    (typeof value === 'number' && Number.isFinite(value))
+  ) {
+    return value as JsonValue;
+  }
+
+  if (Array.isArray(value)) {
+    const result: JsonValue[] = [];
+    for (const entry of value) {
+      const normalized = toPlainJson(entry);
+      if (normalized !== undefined) {
+        result.push(normalized);
+      }
+    }
+    return result;
+  }
+
+  if (typeof value === 'object') {
+    const result: Record<string, JsonValue> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      const normalized = toPlainJson(entry);
+      if (normalized !== undefined) {
+        result[key] = normalized;
+      }
+    }
+    return result;
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(value)) as JsonValue;
+  } catch {
+    return undefined;
+  }
+}
+
+export function dedupePointers(pointers: readonly TokenPointer[]): TokenPointer[] {
+  if (pointers.length === 0) {
+    return [];
+  }
+
+  const unique = new Map<string, TokenPointer>();
+  for (const pointer of pointers) {
+    const key = `${pointer.uri}::${pointer.pointer}`;
+    if (!unique.has(key)) {
+      unique.set(key, pointer);
+    }
+  }
+
+  return Array.from(unique.values());
+}

--- a/parser/src/tokens/parse-tokens.ts
+++ b/parser/src/tokens/parse-tokens.ts
@@ -1,0 +1,644 @@
+import { createHash } from 'node:crypto';
+
+import type { DesignTokenInterchangeFormat } from '@lapidist/dtif-schema';
+
+import { createSession } from '../session.js';
+import type { ParseSession } from '../session.js';
+import type { ParseSessionOptions } from '../session.js';
+import type {
+  ParseInput,
+  ParseResult,
+  RawDocument,
+  Diagnostic,
+  ContentType,
+  DocumentHandle
+} from '../types.js';
+import type { DocumentGraph } from '../graph/nodes.js';
+import { createDocumentResolver } from '../resolver/index.js';
+import type { DocumentResolver } from '../resolver/index.js';
+import { flattenTokens } from './flatten.js';
+import { createMetadataSnapshot, createResolutionSnapshot } from './snapshots.js';
+import {
+  computeDocumentHash,
+  createCacheKey,
+  type ParseCache,
+  type ParseCacheEntry,
+  type ParseCacheKey
+} from './cache.js';
+import { toTokenDiagnostic } from './diagnostics.js';
+import type {
+  DtifFlattenedToken,
+  ResolvedTokenView,
+  TokenDiagnostic,
+  TokenDiagnosticContext,
+  TokenId,
+  TokenMetadataSnapshot
+} from './types.js';
+import { DiagnosticBag } from '../diagnostics/bag.js';
+import { normalizeDocument } from '../ast/normaliser.js';
+import { buildDocumentGraph } from '../graph/builder.js';
+import { decodeBytes } from '../io/decoder/encoding.js';
+import { createSyntheticSourceMap } from '../io/decoder/synthetic-source-map.js';
+import { parseYaml, toJavaScript } from '../io/decoder/yaml.js';
+import { buildSourceMap } from '../io/decoder/source-map.js';
+import { cloneJsonValue } from '../utils/clone-json.js';
+import { hashJsonValue } from '../utils/hash-json.js';
+
+export interface ParseTokensOptions extends Omit<ParseSessionOptions, 'cache'> {
+  readonly flatten?: boolean;
+  readonly includeGraphs?: boolean;
+  readonly cache?: ParseCache;
+  readonly documentCache?: ParseSessionOptions['cache'];
+  readonly onDiagnostic?: (diagnostic: TokenDiagnostic) => void;
+  readonly warn?: (diagnostic: TokenDiagnostic) => void;
+}
+
+export type ParseTokensInput =
+  | ParseInput
+  | DesignTokenInterchangeFormat
+  | { readonly contents: string; readonly uri?: string };
+
+export interface ParseTokensResult {
+  readonly document?: RawDocument;
+  readonly graph?: DocumentGraph;
+  readonly resolver?: DocumentResolver;
+  readonly flattened: readonly DtifFlattenedToken[];
+  readonly metadataIndex: ReadonlyMap<TokenId, TokenMetadataSnapshot>;
+  readonly resolutionIndex: ReadonlyMap<TokenId, ResolvedTokenView>;
+  readonly diagnostics: readonly TokenDiagnostic[];
+}
+
+export async function parseTokens(
+  input: ParseTokensInput,
+  options: ParseTokensOptions = {}
+): Promise<ParseTokensResult> {
+  const {
+    flatten = true,
+    includeGraphs = true,
+    cache: parseCache,
+    documentCache,
+    onDiagnostic,
+    warn,
+    ...sessionOptions
+  } = options;
+
+  const session = createSession({ ...sessionOptions, cache: documentCache });
+  const normalizedInput = normalizeInput(input);
+  const result = await session.parseDocument(normalizedInput);
+  const cacheContext =
+    parseCache && result.document
+      ? await resolveCacheContextAsync(parseCache, result.document, session)
+      : undefined;
+  const artifacts = buildParseTokensArtifacts(
+    result,
+    { session, flatten, includeGraphs, onDiagnostic, warn },
+    cacheContext
+  );
+
+  if (parseCache && cacheContext && artifacts.cacheEntry) {
+    await ensureAsync(parseCache.set(cacheContext.key, artifacts.cacheEntry));
+  }
+
+  return artifacts.outcome;
+}
+
+export function parseTokensSync(
+  input: ParseTokensInput,
+  options: ParseTokensOptions = {}
+): ParseTokensResult {
+  const {
+    flatten = true,
+    includeGraphs = true,
+    cache: parseCache,
+    documentCache,
+    onDiagnostic,
+    warn,
+    ...sessionOptions
+  } = options;
+
+  if (documentCache) {
+    throw new Error('parseTokensSync does not support document caches.');
+  }
+
+  const inline = normalizeInlineInput(input);
+  if (!inline) {
+    throw new Error('parseTokensSync requires inline content or design token objects.');
+  }
+
+  const session = createSession(sessionOptions);
+  const handle = createInlineHandle(inline);
+  const diagnostics = new DiagnosticBag();
+  const document = decodeDocumentSync(handle);
+
+  const schemaResult = session.options.schemaGuard.validate(document);
+  if (!schemaResult.valid) {
+    diagnostics.addMany(schemaResult.diagnostics);
+    return finalizeSync({ document, diagnostics } satisfies ParseResult, {
+      session,
+      flatten,
+      includeGraphs,
+      parseCache,
+      onDiagnostic,
+      warn
+    });
+  }
+
+  const normalised = normalizeDocument(document, {
+    extensions: session.options.plugins
+  });
+  diagnostics.addMany(normalised.diagnostics);
+
+  if (!normalised.ast) {
+    return finalizeSync(
+      {
+        document,
+        diagnostics,
+        extensions: normalised.extensions
+      } satisfies ParseResult,
+      { session, flatten, includeGraphs, parseCache, onDiagnostic, warn }
+    );
+  }
+
+  const graphResult = buildDocumentGraph(normalised.ast);
+  diagnostics.addMany(graphResult.diagnostics);
+  const graph = graphResult.graph;
+
+  const resolver =
+    graph &&
+    createDocumentResolver(graph, {
+      context: session.options.overrideContext,
+      maxDepth: session.options.maxDepth,
+      document,
+      transforms: session.options.plugins?.transforms
+    });
+
+  return finalizeSync(
+    {
+      document,
+      graph,
+      resolver,
+      diagnostics,
+      extensions: normalised.extensions,
+      ast: normalised.ast
+    },
+    { session, flatten, includeGraphs, parseCache, onDiagnostic, warn }
+  );
+}
+
+function normalizeInput(input: ParseTokensInput): ParseInput {
+  if (typeof input === 'object' && input !== null) {
+    if (isParseInputRecord(input)) {
+      return input;
+    }
+
+    if (isContentsRecord(input)) {
+      return {
+        uri: input.uri,
+        content: input.contents
+      };
+    }
+
+    return input as ParseInput;
+  }
+
+  return input as ParseInput;
+}
+
+function isParseInputRecord(value: unknown): value is { content: string | Uint8Array } {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  return 'content' in (value as Record<string, unknown>);
+}
+
+function isContentsRecord(value: unknown): value is { contents: string; uri?: string } {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  return 'contents' in (value as Record<string, unknown>);
+}
+
+function isParseDataRecord(value: unknown): value is {
+  readonly data: DesignTokenInterchangeFormat;
+  readonly uri?: string | URL;
+  readonly contentType?: ContentType;
+} {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  return 'data' in (value as Record<string, unknown>);
+}
+
+function createMemoryUriFromDesignTokens(
+  value: DesignTokenInterchangeFormat,
+  kind: string
+): string {
+  const hash = hashJsonValue(value, { algorithm: 'sha1' });
+  return `memory://dtif-${kind}/${hash}.json`;
+}
+
+interface FinalizeOptions {
+  readonly session: ParseSession;
+  readonly flatten: boolean;
+  readonly includeGraphs: boolean;
+  readonly onDiagnostic?: (diagnostic: TokenDiagnostic) => void;
+  readonly warn?: (diagnostic: TokenDiagnostic) => void;
+}
+
+interface CacheContext {
+  readonly key: ParseCacheKey;
+  readonly documentHash: string;
+  readonly entry?: ParseCacheEntry;
+}
+
+interface FinalizeArtifacts {
+  readonly outcome: ParseTokensResult;
+  readonly cacheEntry?: ParseCacheEntry;
+}
+
+function buildParseTokensArtifacts(
+  result: ParseResult,
+  options: FinalizeOptions,
+  cacheContext?: CacheContext
+): FinalizeArtifacts {
+  const document = result.document;
+  const graph = result.graph;
+  const resolver = result.resolver;
+  const includeGraphs = options.includeGraphs;
+  const flatten = options.flatten;
+
+  const diagnosticContext: TokenDiagnosticContext = {
+    documentUri: document?.uri.href,
+    pointerSpans: document?.sourceMap?.pointers
+  };
+
+  const baseDiagnostics = result.diagnostics.toArray();
+  const parseDiagnostics = baseDiagnostics.map((diagnostic) =>
+    toTokenDiagnostic(diagnostic, diagnosticContext)
+  );
+
+  if (!document || !graph || !resolver) {
+    const outcome = {
+      document: includeGraphs ? document : undefined,
+      graph: includeGraphs ? graph : undefined,
+      resolver: includeGraphs ? resolver : undefined,
+      flattened: [],
+      metadataIndex: graph ? createMetadataSnapshot(graph) : new Map(),
+      resolutionIndex: new Map(),
+      diagnostics: parseDiagnostics
+    } satisfies ParseTokensResult;
+
+    notifyDiagnostics(outcome.diagnostics, options);
+
+    return { outcome } satisfies FinalizeArtifacts;
+  }
+
+  if (cacheContext?.entry && cacheContext.entry.documentHash === cacheContext.documentHash) {
+    const cachedDiagnostics = mergeDiagnostics(
+      cacheContext.entry.diagnostics ?? [],
+      parseDiagnostics
+    );
+    const outcome = {
+      document: includeGraphs ? document : undefined,
+      graph: includeGraphs ? graph : undefined,
+      resolver: includeGraphs ? resolver : undefined,
+      flattened: flatten
+        ? cacheContext.entry.flattened
+          ? [...cacheContext.entry.flattened]
+          : []
+        : [],
+      metadataIndex: cacheContext.entry.metadataIndex
+        ? new Map(cacheContext.entry.metadataIndex)
+        : new Map(),
+      resolutionIndex: cacheContext.entry.resolutionIndex
+        ? new Map(cacheContext.entry.resolutionIndex)
+        : new Map(),
+      diagnostics: cachedDiagnostics
+    } satisfies ParseTokensResult;
+
+    notifyDiagnostics(outcome.diagnostics, options);
+
+    return { outcome } satisfies FinalizeArtifacts;
+  }
+
+  const resolutionDiagnostics: Diagnostic[] = [];
+  const metadataIndex = createMetadataSnapshot(graph);
+  const resolutionIndex = flatten
+    ? createResolutionSnapshot(graph, resolver, {
+        onDiagnostic: (diagnostic) => resolutionDiagnostics.push(diagnostic)
+      })
+    : new Map<TokenId, ResolvedTokenView>();
+
+  const flattened = flatten ? flattenTokens(graph, resolutionIndex) : [];
+  const formattedResolutionDiagnostics = resolutionDiagnostics.map((diagnostic) =>
+    toTokenDiagnostic(diagnostic, diagnosticContext)
+  );
+  const diagnostics = mergeDiagnostics(parseDiagnostics, formattedResolutionDiagnostics);
+
+  notifyDiagnostics(diagnostics, options);
+
+  const cacheEntry: ParseCacheEntry | undefined = cacheContext
+    ? {
+        documentHash: cacheContext.documentHash,
+        flattened: flatten ? flattened : undefined,
+        metadataIndex,
+        resolutionIndex: flatten ? resolutionIndex : undefined,
+        diagnostics,
+        timestamp: Date.now()
+      }
+    : undefined;
+
+  return {
+    outcome: {
+      document: includeGraphs ? document : undefined,
+      graph: includeGraphs ? graph : undefined,
+      resolver: includeGraphs ? resolver : undefined,
+      flattened,
+      metadataIndex,
+      resolutionIndex,
+      diagnostics
+    },
+    cacheEntry
+  } satisfies FinalizeArtifacts;
+}
+
+interface SyncFinalizeOptions extends FinalizeOptions {
+  readonly parseCache?: ParseCache;
+}
+
+function finalizeSync(result: ParseResult, options: SyncFinalizeOptions): ParseTokensResult {
+  const cacheContext =
+    options.parseCache && result.document
+      ? resolveCacheContextSync(options.parseCache, result.document, options.session)
+      : undefined;
+  const artifacts = buildParseTokensArtifacts(result, options, cacheContext);
+
+  if (options.parseCache && cacheContext && artifacts.cacheEntry) {
+    ensureSync(options.parseCache.set(cacheContext.key, artifacts.cacheEntry));
+  }
+
+  return artifacts.outcome;
+}
+
+async function resolveCacheContextAsync(
+  cache: ParseCache,
+  document: RawDocument,
+  session: ParseSession
+): Promise<CacheContext> {
+  const documentHash = computeDocumentHash(document);
+  const key = createCacheKey(document.uri.href, session.options);
+  const entry = await ensureAsync(cache.get(key));
+  return { key, documentHash, entry: entry ?? undefined } satisfies CacheContext;
+}
+
+function resolveCacheContextSync(
+  cache: ParseCache,
+  document: RawDocument,
+  session: ParseSession
+): CacheContext {
+  const documentHash = computeDocumentHash(document);
+  const key = createCacheKey(document.uri.href, session.options);
+  const candidate = cache.get(key);
+  if (isPromiseLike(candidate)) {
+    throw new Error('parseTokensSync requires caches with synchronous get/set semantics.');
+  }
+  return { key, documentHash, entry: candidate ?? undefined } satisfies CacheContext;
+}
+
+async function ensureAsync<T>(value: T | Promise<T>): Promise<T> {
+  return isPromiseLike(value) ? await value : value;
+}
+
+function ensureSync<T>(value: T | Promise<T>): T {
+  if (isPromiseLike(value)) {
+    throw new Error('parseTokensSync requires caches with synchronous get/set semantics.');
+  }
+  return value;
+}
+
+function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
+  return typeof (value as PromiseLike<T>)?.then === 'function';
+}
+
+function notifyDiagnostics(
+  diagnostics: readonly TokenDiagnostic[],
+  options: Pick<FinalizeOptions, 'onDiagnostic' | 'warn'>
+): void {
+  if (diagnostics.length === 0) {
+    return;
+  }
+
+  if (options.onDiagnostic) {
+    for (const diagnostic of diagnostics) {
+      options.onDiagnostic(diagnostic);
+    }
+  }
+
+  if (options.warn) {
+    for (const diagnostic of diagnostics) {
+      if (diagnostic.severity !== 'error') {
+        options.warn(diagnostic);
+      }
+    }
+  }
+}
+
+function mergeDiagnostics(
+  ...groups: readonly (readonly TokenDiagnostic[])
+): readonly TokenDiagnostic[] {
+  const map = new Map<string, TokenDiagnostic>();
+  for (const group of groups) {
+    for (const diagnostic of group) {
+      const key = createDiagnosticKey(diagnostic);
+      map.set(key, diagnostic);
+    }
+  }
+  return Array.from(map.values());
+}
+
+function createDiagnosticKey(diagnostic: TokenDiagnostic): string {
+  const { severity, code, message, target } = diagnostic;
+  const range = target.range;
+  const parts = [
+    severity,
+    code,
+    message,
+    target.uri,
+    range.start.line,
+    range.start.character,
+    range.end.line,
+    range.end.character
+  ];
+  return parts.join('|');
+}
+
+interface InlineInput {
+  readonly uri: string;
+  readonly contentType: ContentType;
+  readonly text?: string;
+  readonly data?: DesignTokenInterchangeFormat;
+}
+
+function normalizeInlineInput(input: ParseTokensInput): InlineInput | undefined {
+  if (typeof input === 'string') {
+    if (!looksLikeInlineDocument(input)) {
+      return undefined;
+    }
+    const text = input;
+    const hash = createHash('sha1').update(text).digest('hex');
+    return {
+      uri: `memory://dtif-inline/${hash}.yaml`,
+      text,
+      contentType: detectContentTypeFromContent(text) ?? 'application/yaml'
+    } satisfies InlineInput;
+  }
+
+  if (input instanceof Uint8Array || input instanceof URL) {
+    return undefined;
+  }
+
+  if (typeof input === 'object' && input !== null) {
+    if (isParseInputRecord(input)) {
+      const content =
+        typeof input.content === 'string' ? input.content : new TextDecoder().decode(input.content);
+      return {
+        uri:
+          typeof input.uri === 'string'
+            ? input.uri
+            : (input.uri?.toString() ?? createMemoryUriFromText(content)),
+        text: content,
+        contentType:
+          input.contentType ?? detectContentTypeFromContent(content) ?? 'application/json'
+      } satisfies InlineInput;
+    }
+
+    if (isContentsRecord(input)) {
+      return {
+        uri: input.uri ?? createMemoryUriFromText(input.contents),
+        text: input.contents,
+        contentType: detectContentTypeFromContent(input.contents) ?? 'application/json'
+      } satisfies InlineInput;
+    }
+
+    if (isParseDataRecord(input)) {
+      const uri =
+        typeof input.uri === 'string'
+          ? input.uri
+          : (input.uri?.toString() ?? createMemoryUriFromDesignTokens(input.data, 'token'));
+      return {
+        uri,
+        contentType: input.contentType ?? 'application/json',
+        data: input.data
+      } satisfies InlineInput;
+    }
+
+    const uri = createMemoryUriFromDesignTokens(input as DesignTokenInterchangeFormat, 'token');
+    return {
+      uri,
+      contentType: 'application/json',
+      data: input as DesignTokenInterchangeFormat
+    } satisfies InlineInput;
+  }
+
+  return undefined;
+}
+
+function looksLikeInlineDocument(value: string): boolean {
+  const trimmed = value.trimStart();
+  if (trimmed.length === 0) {
+    return true;
+  }
+  if (trimmed.startsWith('{') || trimmed.startsWith('[') || trimmed.startsWith('---')) {
+    return true;
+  }
+  if (trimmed.startsWith('%YAML') || trimmed.includes('\n')) {
+    return true;
+  }
+  return false;
+}
+
+function detectContentTypeFromContent(value: string): ContentType | undefined {
+  const trimmed = value.trimStart();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    return 'application/json';
+  }
+  if (trimmed.startsWith('---') || trimmed.startsWith('%YAML') || trimmed.includes('\n')) {
+    return 'application/yaml';
+  }
+  return undefined;
+}
+
+function createMemoryUriFromText(text: string): string {
+  const hash = createHash('sha1').update(text).digest('hex');
+  return `memory://dtif-inline/${hash}.txt`;
+}
+
+function createInlineHandle(input: InlineInput): DocumentHandle {
+  const encoder = new TextEncoder();
+  const bytes = typeof input.text === 'string' ? encoder.encode(input.text) : new Uint8Array(0);
+  const uri = new URL(input.uri);
+  const handle: DocumentHandle = {
+    uri,
+    contentType: input.contentType,
+    bytes,
+    text: input.text
+  };
+
+  if (input.data !== undefined) {
+    handle.data = cloneJsonValue(input.data);
+  }
+
+  return Object.freeze(handle);
+}
+
+function decodeDocumentSync(handle: DocumentHandle): RawDocument {
+  if (handle.data !== undefined) {
+    return Object.freeze(createRawDocumentFromProvidedData(handle));
+  }
+
+  const { text } = decodeBytes(handle.bytes);
+  const { document: yamlDocument, lineCounter } = parseYaml(text);
+  const data = toJavaScript(yamlDocument);
+  const sourceMap = buildSourceMap(handle, text, yamlDocument.contents, lineCounter);
+
+  return Object.freeze({
+    uri: handle.uri,
+    contentType: handle.contentType,
+    bytes: handle.bytes,
+    text,
+    data,
+    sourceMap
+  });
+}
+
+function createRawDocumentFromProvidedData(handle: DocumentHandle): RawDocument {
+  if (typeof handle.text === 'string' && handle.text.length > 0) {
+    const text = handle.text;
+    const { document: yamlDocument, lineCounter } = parseYaml(text);
+    const sourceMap = buildSourceMap(handle, text, yamlDocument.contents, lineCounter);
+    const data = handle.data!;
+
+    return {
+      uri: handle.uri,
+      contentType: handle.contentType,
+      bytes: handle.bytes,
+      text,
+      data,
+      sourceMap
+    } satisfies RawDocument;
+  }
+
+  const text = handle.text ?? '';
+  const data = handle.data!;
+  const sourceMap = createSyntheticSourceMap(handle.uri, data);
+
+  return {
+    uri: handle.uri,
+    contentType: handle.contentType,
+    bytes: handle.bytes,
+    text,
+    data,
+    sourceMap
+  } satisfies RawDocument;
+}

--- a/parser/src/tokens/snapshots.ts
+++ b/parser/src/tokens/snapshots.ts
@@ -1,0 +1,213 @@
+import type { DocumentGraph } from '../graph/nodes.js';
+import type { DocumentResolver } from '../resolver/index.js';
+import type { Diagnostic } from '../types.js';
+import { dedupePointers, toPlainJson } from './internal/utils.js';
+import { getBaseType, getBaseValue, getTokenId, iterateTokenNodes } from './internal/graph.js';
+import type { ResolvedTokenView, TokenId, TokenMetadataSnapshot, TokenPointer } from './types.js';
+import type { NodeMetadata } from '../ast/nodes.js';
+
+export function createMetadataSnapshot(graph: DocumentGraph): Map<TokenId, TokenMetadataSnapshot> {
+  const entries = new Map<TokenId, TokenMetadataSnapshot>();
+  const documentUri = graph.uri.href;
+
+  for (const node of iterateTokenNodes(graph)) {
+    const id = getTokenId(node.pointer);
+    const sourceUri = node.span?.uri?.href ?? documentUri;
+    const metadata = normalizeMetadata(
+      node.metadata,
+      {
+        uri: sourceUri,
+        line: node.span?.start?.line,
+        column: node.span?.start?.column
+      },
+      documentUri
+    );
+
+    entries.set(id, metadata);
+  }
+
+  return entries;
+}
+
+export function createResolutionSnapshot(
+  graph: DocumentGraph,
+  resolver: DocumentResolver,
+  options: { onDiagnostic?: (diagnostic: Diagnostic) => void } = {}
+): Map<TokenId, ResolvedTokenView> {
+  const entries = new Map<TokenId, ResolvedTokenView>();
+  const documentUri = graph.uri.href;
+  const forwardDiagnostic = options.onDiagnostic;
+
+  for (const node of iterateTokenNodes(graph)) {
+    const pointer = getTokenId(node.pointer);
+    const id = pointer;
+    const baseType = getBaseType(node);
+    const rawValue = getBaseValue(node);
+    const resolution = resolver.resolve(pointer);
+    if (forwardDiagnostic) {
+      for (const diagnostic of resolution.diagnostics) {
+        forwardDiagnostic(diagnostic);
+      }
+    }
+    const resolvedToken = resolution.token;
+
+    const value = resolvedToken?.value ?? rawValue;
+    const normalizedValue = toPlainJson(value);
+    const normalizedRaw = toPlainJson(rawValue);
+
+    const references: TokenPointer[] = [];
+    if (node.kind === 'alias') {
+      const target = node.ref.value;
+      references.push({
+        uri: target.uri.href,
+        pointer: getTokenId(target.pointer)
+      });
+    }
+
+    if (resolvedToken?.overridesApplied) {
+      for (const override of resolvedToken.overridesApplied) {
+        if (override.source) {
+          references.push({
+            uri: override.source.uri.href,
+            pointer: getTokenId(override.source.pointer)
+          });
+        }
+      }
+    }
+
+    const resolutionPath: TokenPointer[] = [];
+    const appliedAliases: TokenPointer[] = [];
+    if (resolvedToken) {
+      if (forwardDiagnostic && resolvedToken.warnings) {
+        for (const warning of resolvedToken.warnings) {
+          forwardDiagnostic(warning);
+        }
+      }
+      for (const step of resolvedToken.trace) {
+        const tokenPointer: TokenPointer = {
+          uri: documentUri,
+          pointer: getTokenId(step.pointer)
+        };
+        resolutionPath.push(tokenPointer);
+        if (step.kind === 'alias') {
+          appliedAliases.push(tokenPointer);
+        }
+      }
+
+      if (resolvedToken.source) {
+        references.push({
+          uri: resolvedToken.source.uri.href,
+          pointer: getTokenId(resolvedToken.source.pointer)
+        });
+      }
+    }
+
+    entries.set(id, {
+      id,
+      type: resolvedToken?.type ?? baseType,
+      value: normalizedValue,
+      raw: normalizedRaw,
+      references: dedupePointers(references),
+      resolutionPath: dedupePointers(resolutionPath),
+      appliedAliases: dedupePointers(appliedAliases)
+    });
+  }
+
+  return entries;
+}
+
+function normalizeMetadata(
+  metadata: NodeMetadata,
+  source: { uri: string; line?: number; column?: number },
+  documentUri: string
+): TokenMetadataSnapshot {
+  const description =
+    typeof metadata.description?.value === 'string' ? metadata.description.value : undefined;
+  const extensions = cloneExtensions(metadata.extensions);
+  const deprecated = normalizeDeprecated(metadata, documentUri);
+  const line = Number.isFinite(source.line) ? (source.line as number) : 1;
+  const column = Number.isFinite(source.column) ? (source.column as number) : 1;
+
+  return {
+    description,
+    extensions,
+    deprecated,
+    source: {
+      uri: source.uri,
+      line,
+      column
+    }
+  };
+}
+
+function cloneExtensions(value: NodeMetadata['extensions']): Record<string, unknown> {
+  const extensionsValue = value?.value;
+  if (!extensionsValue || typeof extensionsValue !== 'object') {
+    return {};
+  }
+
+  const copy: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(extensionsValue as Record<string, unknown>)) {
+    const cloned = toPlainJson(entry);
+    copy[key] = cloned === undefined ? entry : cloned;
+  }
+
+  return copy;
+}
+
+function normalizeDeprecated(
+  metadata: NodeMetadata,
+  documentUri: string
+): TokenMetadataSnapshot['deprecated'] {
+  const deprecated = metadata.deprecated?.value;
+  if (!deprecated || typeof deprecated !== 'object') {
+    return undefined;
+  }
+
+  if ('active' in deprecated && deprecated.active) {
+    const replacementField = (deprecated as { readonly replacement?: { readonly value: string } })
+      .replacement;
+    const supersededBy = replacementField
+      ? createTokenPointer(replacementField.value, documentUri)
+      : undefined;
+
+    if (supersededBy) {
+      return { supersededBy };
+    }
+
+    return {};
+  }
+
+  return undefined;
+}
+
+function createTokenPointer(
+  reference: string | undefined,
+  documentUri: string
+): TokenMetadataSnapshot['deprecated'] extends infer T
+  ? T extends { supersededBy?: infer P }
+    ? P
+    : never
+  : never {
+  if (!reference || typeof reference !== 'string') {
+    return undefined as never;
+  }
+
+  try {
+    const trimmed = reference.trim();
+    if (trimmed.length === 0) {
+      return undefined as never;
+    }
+
+    const base = new URL(documentUri);
+    const resolved = new URL(trimmed, base);
+    const pointer = getTokenId(resolved.hash || trimmed);
+    resolved.hash = '';
+    return {
+      uri: resolved.href,
+      pointer
+    } as never;
+  } catch {
+    return undefined as never;
+  }
+}

--- a/parser/src/tokens/types.ts
+++ b/parser/src/tokens/types.ts
@@ -1,0 +1,85 @@
+import type { JsonPointer, SourceSpan } from '../types.js';
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { readonly [key: string]: JsonValue };
+
+export type TokenId = string;
+export type TokenType = string;
+
+export interface Position {
+  readonly line: number;
+  readonly character: number;
+}
+
+export interface Range {
+  readonly start: Position;
+  readonly end: Position;
+}
+
+export interface TokenPointer {
+  readonly uri: string;
+  readonly pointer: JsonPointer;
+}
+
+export interface DtifFlattenedToken {
+  readonly id: TokenId;
+  readonly pointer: JsonPointer;
+  readonly name: string;
+  readonly path: readonly string[];
+  readonly type?: TokenType;
+  readonly value?: JsonValue;
+  readonly raw?: JsonValue;
+}
+
+export interface TokenMetadataSnapshot {
+  readonly description?: string;
+  readonly extensions: Record<string, unknown>;
+  readonly deprecated?: {
+    readonly since?: string;
+    readonly reason?: string;
+    readonly supersededBy?: TokenPointer;
+  };
+  readonly source: {
+    readonly uri: string;
+    readonly line: number;
+    readonly column: number;
+  };
+}
+
+export interface ResolvedTokenView {
+  readonly id: TokenId;
+  readonly type?: TokenType;
+  readonly value?: JsonValue;
+  readonly raw?: JsonValue;
+  readonly references: readonly TokenPointer[];
+  readonly resolutionPath: readonly TokenPointer[];
+  readonly appliedAliases: readonly TokenPointer[];
+}
+
+export interface TokenDiagnostic {
+  readonly severity: 'error' | 'warning' | 'info';
+  readonly code: string;
+  readonly message: string;
+  readonly source: 'dtif-parser';
+  readonly target: {
+    readonly uri: string;
+    readonly range: Range;
+  };
+  readonly related?: readonly {
+    readonly message: string;
+    readonly target: {
+      readonly uri: string;
+      readonly range: Range;
+    };
+  }[];
+}
+
+export interface TokenDiagnosticContext {
+  readonly documentUri?: string;
+  readonly pointerSpans?: ReadonlyMap<JsonPointer, SourceSpan>;
+}
+
+export interface FormatTokenDiagnosticOptions {
+  readonly color?: boolean;
+  readonly cwd?: string;
+}

--- a/parser/src/types.ts
+++ b/parser/src/types.ts
@@ -1,3 +1,4 @@
+import type { DesignTokenInterchangeFormat } from '@lapidist/dtif-schema';
 import type { DiagnosticBag } from './diagnostics/bag.js';
 import type { DiagnosticCode } from './diagnostics/codes.js';
 import type { DiagnosticSeverity } from './diagnostics/severity.js';
@@ -8,11 +9,23 @@ import type { ExtensionEvaluation } from './plugins/index.js';
 
 export type JsonPointer = `#${string}`;
 
-export type ParseInput = string | Uint8Array | URL | ParseInputRecord;
+export type ParseInput =
+  | string
+  | Uint8Array
+  | URL
+  | ParseInputRecord
+  | ParseDataInputRecord
+  | DesignTokenInterchangeFormat;
 
 export interface ParseInputRecord {
   readonly uri?: string | URL;
   readonly content: string | Uint8Array;
+  readonly contentType?: ContentType;
+}
+
+export interface ParseDataInputRecord {
+  readonly uri?: string | URL;
+  readonly data: DesignTokenInterchangeFormat;
   readonly contentType?: ContentType;
 }
 
@@ -54,6 +67,8 @@ export interface DocumentHandle {
   readonly uri: URL;
   readonly contentType: ContentType;
   readonly bytes: Uint8Array;
+  readonly text?: string;
+  readonly data?: unknown;
 }
 
 export interface RawDocument extends DocumentHandle {

--- a/parser/src/utils/clone-json.ts
+++ b/parser/src/utils/clone-json.ts
@@ -1,0 +1,18 @@
+export function cloneJsonValue<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneJsonValue(item)) as unknown as T;
+  }
+
+  if (value && typeof value === 'object') {
+    const prototype = Object.getPrototypeOf(value as object);
+    const clone: Record<string, unknown> = Object.create(prototype ?? null);
+
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      clone[key] = cloneJsonValue(entry);
+    }
+
+    return clone as unknown as T;
+  }
+
+  return value;
+}

--- a/parser/src/utils/hash-json.ts
+++ b/parser/src/utils/hash-json.ts
@@ -1,0 +1,83 @@
+import { createHash, type Hash } from 'node:crypto';
+
+export interface HashJsonValueOptions {
+  readonly algorithm?: string;
+}
+
+export function hashJsonValue(value: unknown, options: HashJsonValueOptions = {}): string {
+  const { algorithm = 'sha256' } = options;
+  const hash = createHash(algorithm);
+  updateHashWithValue(hash, value);
+  return hash.digest('hex');
+}
+
+function updateHashWithValue(hash: Hash, value: unknown): void {
+  if (value === null) {
+    hash.update('null');
+    return;
+  }
+
+  switch (typeof value) {
+    case 'undefined': {
+      hash.update('undefined');
+      return;
+    }
+    case 'boolean': {
+      hash.update('bool:');
+      hash.update(value ? '1' : '0');
+      return;
+    }
+    case 'number': {
+      hash.update('number:');
+      hash.update(Number.isFinite(value) ? value.toString() : 'NaN');
+      return;
+    }
+    case 'bigint': {
+      hash.update('bigint:');
+      hash.update(value.toString());
+      return;
+    }
+    case 'string': {
+      hash.update('string:');
+      hash.update(value);
+      return;
+    }
+    case 'symbol': {
+      hash.update('symbol:');
+      hash.update(String(value.description ?? ''));
+      return;
+    }
+    case 'function': {
+      hash.update('function');
+      return;
+    }
+    case 'object': {
+      if (Array.isArray(value)) {
+        hash.update('array[');
+        hash.update(value.length.toString());
+        hash.update(']:');
+        for (const item of value) {
+          updateHashWithValue(hash, item);
+          hash.update(';');
+        }
+        return;
+      }
+
+      hash.update('object{');
+      const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+        a.localeCompare(b)
+      );
+      for (const [key, entryValue] of entries) {
+        hash.update(key);
+        hash.update(':');
+        updateHashWithValue(hash, entryValue);
+        hash.update(';');
+      }
+      hash.update('}');
+      return;
+    }
+    default: {
+      hash.update('unknown');
+    }
+  }
+}

--- a/parser/src/utils/stable-json.ts
+++ b/parser/src/utils/stable-json.ts
@@ -1,0 +1,22 @@
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(normalizeForStringify(value));
+}
+
+function normalizeForStringify(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeForStringify);
+  }
+
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+      a.localeCompare(b)
+    );
+    const normalized: Record<string, unknown> = {};
+    for (const [key, entry] of entries) {
+      normalized[key] = normalizeForStringify(entry);
+    }
+    return normalized;
+  }
+
+  return value;
+}

--- a/parser/tests/fixtures/node/invalid.tokens.json
+++ b/parser/tests/fixtures/node/invalid.tokens.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "colors": {
+    "brand": {
+      "primary": {
+        "$type": "color"
+      }
+    }
+  }
+}

--- a/parser/tests/fixtures/node/valid.tokens.json
+++ b/parser/tests/fixtures/node/valid.tokens.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://dtif.lapidist.net/schema/core.json",
+  "colors": {
+    "brand": {
+      "primary": {
+        "$type": "color",
+        "$value": {
+          "colorSpace": "srgb",
+          "components": [0.1, 0.2, 0.3]
+        },
+        "$description": "Primary brand color"
+      }
+    }
+  }
+}

--- a/parser/tests/integration/node-token-parser.test.ts
+++ b/parser/tests/integration/node-token-parser.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DtifTokenParseError,
+  parseTokensFromFile,
+  readTokensFile
+} from '../../src/adapters/node/token-parser.js';
+
+const VALID_FIXTURE = new URL('../fixtures/node/valid.tokens.json', import.meta.url);
+const INVALID_FIXTURE = new URL('../fixtures/node/invalid.tokens.json', import.meta.url);
+
+test('parseTokensFromFile returns flattened tokens for supported files', async () => {
+  const diagnostics: unknown[] = [];
+  const result = await parseTokensFromFile(VALID_FIXTURE, {
+    onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    onWarn: () => {
+      throw new Error('did not expect warnings for valid document');
+    }
+  });
+
+  assert.equal(
+    result.diagnostics.length,
+    diagnostics.length,
+    'expected diagnostic callback to mirror result'
+  );
+  assert.equal(result.flattened.length, 1, 'expected a flattened token to be returned');
+  assert.equal(result.flattened[0]?.name, 'primary');
+});
+
+test('parseTokensFromFile rejects unsupported file extensions', async () => {
+  await assert.rejects(
+    parseTokensFromFile('tokens.json'),
+    /Unsupported design tokens file/,
+    'expected unsupported extensions to throw'
+  );
+});
+
+test('parseTokensFromFile throws DtifTokenParseError for invalid documents', async () => {
+  await assert.rejects(parseTokensFromFile(INVALID_FIXTURE), (error: unknown) => {
+    assert.ok(error instanceof DtifTokenParseError, 'expected DtifTokenParseError instance');
+    assert.ok(error.message.includes('Failed to parse DTIF document'));
+    assert.ok(error.diagnostics.length > 0, 'expected diagnostics on error');
+    const formatted = error.format();
+    assert.ok(formatted.includes('Failed to parse DTIF document'));
+    return true;
+  });
+});
+
+test('readTokensFile returns parsed DTIF contents', async () => {
+  const document = await readTokensFile(VALID_FIXTURE);
+  assert.equal(typeof document, 'object');
+  const colors = (document as Record<string, unknown>).colors as Record<string, any> | undefined;
+  assert.ok(colors?.brand?.primary);
+  assert.equal(colors.brand.primary.$type, 'color');
+});

--- a/parser/tests/integration/parse-collection.test.ts
+++ b/parser/tests/integration/parse-collection.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createSession } from '../../src/session.js';
+import { DiagnosticCodes } from '../../src/diagnostics/codes.js';
+
+const VALID_DOCUMENT = JSON.stringify(
+  {
+    $schema: 'https://dtif.lapidist.net/schema/core.json',
+    color: {
+      brand: {
+        primary: {
+          $type: 'color',
+          $value: {
+            colorSpace: 'srgb',
+            components: [0, 0, 0]
+          }
+        }
+      }
+    }
+  },
+  null,
+  2
+);
+
+const INVALID_DOCUMENT = JSON.stringify(
+  {
+    $schema: 'https://dtif.lapidist.net/schema/core.json',
+    color: {
+      brand: {
+        primary: {
+          $type: 'color',
+          $value: {
+            colorSpace: 'srgb',
+            components: []
+          }
+        }
+      }
+    }
+  },
+  null,
+  2
+);
+
+test('parseCollection returns per-document results with aggregated diagnostics', async () => {
+  const session = createSession();
+  const inputs = [
+    { uri: 'memory://collection/valid.json', content: VALID_DOCUMENT },
+    { uri: 'memory://collection/invalid.json', content: INVALID_DOCUMENT }
+  ];
+
+  const result = await session.parseCollection(inputs);
+
+  assert.equal(result.results.length, 2, 'expected both documents to be parsed');
+
+  const [valid, invalid] = result.results;
+
+  assert.ok(valid.document, 'expected valid document to be decoded');
+  assert.ok(valid.ast, 'expected valid document to produce an AST');
+  assert.ok(valid.graph, 'expected valid document to produce a graph');
+  assert.ok(valid.resolver, 'expected valid document to produce a resolver');
+  assert.equal(valid.diagnostics.hasErrors(), false, 'expected no errors for valid document');
+
+  assert.ok(invalid.document, 'expected invalid document bytes to be returned');
+  assert.equal(invalid.ast, undefined, 'expected AST to be omitted when validation fails');
+  assert.equal(invalid.graph, undefined, 'expected graph to be omitted when validation fails');
+  assert.equal(
+    invalid.resolver,
+    undefined,
+    'expected resolver to be omitted when validation fails'
+  );
+  const invalidDiagnostic = invalid.diagnostics
+    .toArray()
+    .find((entry) => entry.code === DiagnosticCodes.schemaGuard.INVALID_DOCUMENT);
+  assert.ok(invalidDiagnostic, 'expected schema guard diagnostic for invalid document');
+
+  assert.equal(
+    result.diagnostics.errorCount,
+    invalid.diagnostics.errorCount,
+    'expected aggregated diagnostics to include per-document errors'
+  );
+  assert.ok(
+    result.diagnostics
+      .toArray()
+      .some((entry) => entry.code === DiagnosticCodes.schemaGuard.INVALID_DOCUMENT),
+    'expected aggregated diagnostics to expose schema failures'
+  );
+});

--- a/parser/tests/integration/parse-tokens.test.ts
+++ b/parser/tests/integration/parse-tokens.test.ts
@@ -1,0 +1,249 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { parseTokens, parseTokensSync } from '../../src/tokens/parse-tokens.js';
+import type { ParseCache, ParseCacheEntry, ParseCacheKey } from '../../src/tokens/cache.js';
+import { computeDocumentHash } from '../../src/tokens/cache.js';
+import type { TokenDiagnostic } from '../../src/tokens/types.js';
+
+const INLINE_DOCUMENT = `
+$schema: https://dtif.lapidist.net/schema/core.json
+colors:
+  primary:
+    $type: color
+    $value:
+      colorSpace: srgb
+      components: [0.1, 0.2, 0.3]
+    $description: Primary brand color
+    $extensions:
+      vendor.test:
+        note: keep
+    $deprecated:
+      $replacement: "#/aliases/brand"
+aliases:
+  brand:
+    $type: color
+    $ref: "#/colors/primary"
+`;
+
+test('parseTokens flattens DTIF tokens with metadata and resolution snapshots', async () => {
+  const result = await parseTokens(INLINE_DOCUMENT);
+
+  assert.equal(result.diagnostics.length, 0, 'expected no diagnostics for valid document');
+  assert.ok(result.document, 'expected raw document to be returned');
+  assert.ok(result.graph, 'expected graph to be returned');
+  assert.ok(result.resolver, 'expected resolver to be returned');
+
+  assert.equal(result.flattened.length, 2, 'expected two flattened tokens');
+
+  const primary = result.flattened.find((token) => token.name === 'primary');
+  assert.ok(primary, 'expected primary token to be flattened');
+  assert.equal(primary?.type, 'color', 'expected flattened type to match base type');
+  assert.deepEqual(
+    primary?.value,
+    { colorSpace: 'srgb', components: [0.1, 0.2, 0.3] },
+    'expected flattened value to reflect resolved token'
+  );
+
+  const alias = result.flattened.find((token) => token.name === 'brand');
+  assert.ok(alias, 'expected alias token to be flattened');
+  assert.deepEqual(
+    alias?.value,
+    primary?.value,
+    'expected alias value to resolve to primary value'
+  );
+
+  const primaryMetadata = result.metadataIndex.get('#/colors/primary');
+  assert.ok(primaryMetadata, 'expected metadata snapshot for primary token');
+  assert.equal(primaryMetadata?.description, 'Primary brand color');
+  assert.deepEqual(primaryMetadata?.extensions['vendor.test'], { note: 'keep' });
+  assert.equal(
+    primaryMetadata?.deprecated?.supersededBy?.pointer,
+    '#/aliases/brand',
+    'expected deprecated metadata to resolve replacement pointer'
+  );
+
+  const aliasResolution = result.resolutionIndex.get('#/aliases/brand');
+  assert.ok(aliasResolution, 'expected resolution snapshot for alias token');
+  assert.ok(aliasResolution?.references.some((ref) => ref.pointer === '#/colors/primary'));
+  assert.deepEqual(
+    aliasResolution?.value,
+    primary?.value,
+    'expected alias resolution value to match flattened alias value'
+  );
+});
+
+test('parseTokens accepts in-memory design token objects', async () => {
+  const tokens = {
+    $schema: 'https://dtif.lapidist.net/schema/core.json',
+    colors: {
+      brand: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0.4, 0.4, 0.4] }
+      }
+    }
+  } as const;
+
+  const result = await parseTokens(tokens);
+
+  assert.equal(result.diagnostics.length, 0);
+  assert.equal(result.flattened.length, 1);
+  const [token] = result.flattened;
+  assert.equal(token.name, 'brand');
+  assert.equal(token.type, 'color');
+  assert.ok(result.document, 'expected document to be returned');
+  assert.notEqual(result.document?.data, tokens);
+  assert.deepEqual(result.document?.data, tokens);
+});
+
+test('parseTokens reuses cached artifacts when ParseCache entries are fresh', async () => {
+  const cache = new RecordingParseCache();
+
+  const first = await parseTokens(INLINE_DOCUMENT, { cache });
+  assert.equal(cache.setCalls, 1, 'expected cache to be populated on first parse');
+  assert.equal(first.flattened.length, 2, 'expected flattened tokens from first parse');
+
+  const second = await parseTokens(INLINE_DOCUMENT, { cache });
+  assert.equal(cache.getCalls >= 2, true, 'expected cache to be consulted on reuse');
+  assert.equal(cache.setCalls, 1, 'expected cache entry to be reused without re-writing');
+  assert.equal(second.flattened.length, 2, 'expected flattened tokens from cached parse');
+});
+
+test('parseTokens forwards diagnostics to callbacks', async () => {
+  const invalidDocument = `
+$schema: https://dtif.lapidist.net/schema/core.json
+colors:
+  primary:
+    $type: color
+`;
+
+  const seenDiagnostics: TokenDiagnostic[] = [];
+  let warnCalled = false;
+
+  const result = await parseTokens(invalidDocument, {
+    onDiagnostic: (diagnostic) => {
+      seenDiagnostics.push(diagnostic);
+    },
+    warn: () => {
+      warnCalled = true;
+    }
+  });
+
+  assert.ok(result.diagnostics.length > 0, 'expected diagnostics for invalid document');
+  assert.equal(
+    seenDiagnostics.length,
+    result.diagnostics.length,
+    'expected callback to receive each diagnostic'
+  );
+  assert.equal(warnCalled, false, 'expected warn callback to be skipped for errors');
+});
+
+test('parseTokens invokes warn callbacks for cached non-error diagnostics', async () => {
+  const initial = await parseTokens(INLINE_DOCUMENT);
+  const document = initial.document;
+  assert.ok(document, 'expected document in initial parse');
+
+  const warning: TokenDiagnostic = {
+    severity: 'warning',
+    code: 'cache.warning',
+    message: 'cached warning',
+    source: 'dtif-parser',
+    target: {
+      uri: document.uri.href,
+      range: {
+        start: { line: 0, character: 0 },
+        end: { line: 0, character: 0 }
+      }
+    }
+  };
+
+  const cacheEntry: ParseCacheEntry = {
+    documentHash: computeDocumentHash(document),
+    flattened: initial.flattened,
+    metadataIndex: initial.metadataIndex,
+    resolutionIndex: initial.resolutionIndex,
+    diagnostics: [warning],
+    timestamp: Date.now()
+  };
+
+  const cache: ParseCache = {
+    get() {
+      return cacheEntry;
+    },
+    set() {}
+  };
+
+  const warnings: TokenDiagnostic[] = [];
+  const diagnostics: TokenDiagnostic[] = [];
+
+  const cached = await parseTokens(INLINE_DOCUMENT, {
+    cache,
+    onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    warn: (diagnostic) => warnings.push(diagnostic)
+  });
+
+  assert.equal(cached.diagnostics.length, 1, 'expected cached diagnostic to be returned');
+  assert.equal(diagnostics.length, 1, 'expected onDiagnostic to receive cached diagnostic');
+  assert.equal(warnings.length, 1, 'expected warn callback to receive cached warning');
+  assert.equal(warnings[0].message, 'cached warning');
+});
+
+test('parseTokensSync supports inline strings and design token objects', () => {
+  const syncResult = parseTokensSync(INLINE_DOCUMENT);
+  assert.equal(syncResult.flattened.length, 2, 'expected synchronous parsing to flatten tokens');
+
+  const tokens = {
+    $schema: 'https://dtif.lapidist.net/schema/core.json',
+    colors: {
+      brand: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0.4, 0.4, 0.4] }
+      }
+    }
+  } as const;
+
+  const objectResult = parseTokensSync(tokens);
+  assert.equal(objectResult.flattened.length, 1, 'expected object input to parse synchronously');
+  assert.ok(objectResult.document, 'expected synchronous parse to return document');
+  assert.notEqual(objectResult.document?.data, tokens);
+  assert.deepEqual(objectResult.document?.data, tokens);
+});
+
+test('parseTokensSync throws when provided an asynchronous cache implementation', () => {
+  const asyncCache = new AsyncParseCache();
+  assert.throws(
+    () => parseTokensSync(INLINE_DOCUMENT, { cache: asyncCache }),
+    /synchronous get\/set semantics/,
+    'expected synchronous parsing to reject asynchronous caches'
+  );
+});
+
+class RecordingParseCache implements ParseCache {
+  readonly store = new Map<string, ParseCacheEntry>();
+  getCalls = 0;
+  setCalls = 0;
+
+  get(key: ParseCacheKey): ParseCacheEntry | undefined {
+    this.getCalls += 1;
+    return this.store.get(serializeKey(key));
+  }
+
+  set(key: ParseCacheKey, value: ParseCacheEntry): void {
+    this.setCalls += 1;
+    this.store.set(serializeKey(key), value);
+  }
+}
+
+class AsyncParseCache implements ParseCache {
+  get(): ParseCacheEntry | undefined {
+    return undefined;
+  }
+
+  set(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+function serializeKey(key: ParseCacheKey): string {
+  return `${key.uri}::${key.variant}`;
+}

--- a/parser/tests/unit/tokens/diagnostics.test.ts
+++ b/parser/tests/unit/tokens/diagnostics.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createSourcePosition, createSourceSpan } from '../../../src/utils/source.js';
+import { toTokenDiagnostic, formatTokenDiagnostic } from '../../../src/tokens/diagnostics.js';
+import type { Diagnostic } from '../../../src/types.js';
+
+const DOCUMENT_URI = new URL('file:///tokens.json');
+const POINTER = '#/color/background';
+
+function createSpan() {
+  return createSourceSpan(
+    DOCUMENT_URI,
+    createSourcePosition(0, 1, 1),
+    createSourcePosition(12, 1, 13)
+  );
+}
+
+test('toTokenDiagnostic maps pointer spans when no explicit span is provided', () => {
+  const span = createSpan();
+  const diagnostic: Diagnostic = {
+    code: 'parser.missingValue',
+    message: 'Token is missing a $value property.',
+    severity: 'error',
+    pointer: POINTER
+  };
+
+  const result = toTokenDiagnostic(diagnostic, {
+    documentUri: DOCUMENT_URI.href,
+    pointerSpans: new Map([[POINTER, span]])
+  });
+
+  assert.equal(result.source, 'dtif-parser');
+  assert.equal(result.code, 'parser.missingValue');
+  assert.equal(result.target.uri, DOCUMENT_URI.href);
+  assert.deepEqual(result.target.range, {
+    start: { line: 0, character: 0 },
+    end: { line: 0, character: 12 }
+  });
+});
+
+test('toTokenDiagnostic maps related information entries', () => {
+  const span = createSpan();
+  const relatedSpan = createSourceSpan(
+    DOCUMENT_URI,
+    createSourcePosition(20, 2, 3),
+    createSourcePosition(25, 2, 8)
+  );
+  const diagnostic: Diagnostic = {
+    code: 'resolver.targetMismatch',
+    message: 'Alias type does not match resolved token type.',
+    severity: 'warning',
+    pointer: POINTER,
+    related: [
+      {
+        message: 'Target token resolved here.',
+        pointer: '#/color/base'
+      },
+      {
+        message: 'Alias declared here.',
+        span: relatedSpan
+      }
+    ]
+  };
+
+  const result = toTokenDiagnostic(diagnostic, {
+    documentUri: DOCUMENT_URI.href,
+    pointerSpans: new Map([
+      [POINTER, span],
+      ['#/color/base', span]
+    ])
+  });
+
+  assert.ok(result.related);
+  assert.equal(result.related?.length, 2);
+  assert.deepEqual(result.related?.[0].target.range.start, { line: 0, character: 0 });
+  assert.deepEqual(result.related?.[1].target.range.start, { line: 1, character: 2 });
+});
+
+test('formatTokenDiagnostic renders human readable output', () => {
+  const span = createSpan();
+  const diagnostic = toTokenDiagnostic(
+    {
+      code: 'parser.example',
+      message: 'Example message',
+      severity: 'info',
+      pointer: POINTER
+    },
+    {
+      documentUri: DOCUMENT_URI.href,
+      pointerSpans: new Map([[POINTER, span]])
+    }
+  );
+
+  const formatted = formatTokenDiagnostic(diagnostic, { cwd: '/workspace' });
+
+  assert.match(formatted, /INFO parser.example: Example message/);
+  assert.match(formatted, /tokens.json:1:1/);
+});
+
+test('formatTokenDiagnostic applies ANSI colors when enabled', () => {
+  const span = createSpan();
+  const diagnostic = toTokenDiagnostic(
+    {
+      code: 'parser.failure',
+      message: 'Example failure',
+      severity: 'error',
+      pointer: POINTER
+    },
+    {
+      documentUri: DOCUMENT_URI.href,
+      pointerSpans: new Map([[POINTER, span]])
+    }
+  );
+
+  const formatted = formatTokenDiagnostic(diagnostic, { color: true });
+
+  assert.match(formatted, /\u001b\[31mERROR/);
+});


### PR DESCRIPTION
## Summary
- update the default document loader to clone DTIF objects directly into memory handles with deterministic URIs instead of serialising them first
- teach the decoder and parseTokens helpers to reuse provided data, generate synthetic source maps, and hash raw documents when populating caches
- add shared utilities for hashing JSON payloads, generating synthetic source maps, and expand tests around object inputs and caching

## Testing
- npm run lint:docs
- npm test --prefix parser

------
https://chatgpt.com/codex/tasks/task_e_68d4350dac388328874de697adbe453c