### PR TITLE
Fix changeset fixed group and align package versions

### DIFF
--- a/.changeset/align-parser-fixed.md
+++ b/.changeset/align-parser-fixed.md
@@ -1,0 +1,7 @@
+---
+"@lapidist/dtif-schema": patch
+"@lapidist/dtif-validator": patch
+"@lapidist/dtif-parser": patch
+---
+
+Add the parser to the fixed release group and align package versions.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
     }
   ],
   "commit": false,
-  "fixed": [["@lapidist/dtif-schema", "@lapidist/dtif-validator"]],
+  "fixed": [["@lapidist/dtif-schema", "@lapidist/dtif-validator", "@lapidist/dtif-parser"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6225,11 +6225,11 @@
     },
     "parser": {
       "name": "@lapidist/dtif-parser",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@lapidist/dtif-schema": "^0.2.0",
-        "@lapidist/dtif-validator": "^0.2.0",
+        "@lapidist/dtif-schema": "^0.3.0",
+        "@lapidist/dtif-validator": "^0.3.0",
         "yaml": "^2.8.1"
       },
       "bin": {
@@ -6243,15 +6243,15 @@
     },
     "schema": {
       "name": "@lapidist/dtif-schema",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT"
     },
     "validator": {
       "name": "@lapidist/dtif-validator",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@lapidist/dtif-schema": "^0.2.0",
+        "@lapidist/dtif-schema": "^0.3.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1"
       }

--- a/parser/package.json
+++ b/parser/package.json
@@ -37,8 +37,8 @@
     "prepack": "npm run build"
   },
   "dependencies": {
-    "@lapidist/dtif-schema": "^0.2.1",
-    "@lapidist/dtif-validator": "^0.2.1",
+    "@lapidist/dtif-schema": "^0.3.0",
+    "@lapidist/dtif-validator": "^0.3.0",
     "yaml": "^2.8.1"
   },
   "devDependencies": {

--- a/schema/package.json
+++ b/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lapidist/dtif-schema",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "JSON Schema for the Design Token Interchange Format (DTIF).",
   "type": "module",
   "license": "MIT",

--- a/validator/package.json
+++ b/validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lapidist/dtif-validator",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "AJV helper utilities for validating DTIF documents against the official schema.",
   "type": "module",
   "license": "MIT",
@@ -23,7 +23,7 @@
     "validation"
   ],
   "dependencies": {
-    "@lapidist/dtif-schema": "^0.2.1",
+    "@lapidist/dtif-schema": "^0.3.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1"
   },


### PR DESCRIPTION
## Summary
- include the parser package in the fixed changeset group so all DTIF packages release together
- align the schema and validator package versions with the parser and update internal dependency ranges
- add a patch changeset covering all packages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d464e8f16083288b89c959286f00ce