### PR TITLE
Adjust tooling navigation placement

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -67,7 +67,6 @@ export default defineConfig({
     nav: [
       { text: 'Specification', link: '/spec/' },
       { text: 'Guides', link: '/guides/' },
-      { text: 'Tooling built with DTIF', link: '/tooling/' },
       { text: 'Examples', link: '/examples/' },
       { text: 'Governance', link: '/governance/' },
       { text: 'Roadmap', link: '/roadmap/' }
@@ -118,10 +117,7 @@ export default defineConfig({
           items: [
             { text: 'Tooling overview', link: '/tooling/' },
             { text: 'Design Lint', link: '/tooling/design-lint' },
-            {
-              text: 'DTIF parser API reference',
-              link: '/tooling/dtif-parser-api-reference'
-            }
+            { text: 'Using the DTIF parser', link: '/guides/dtif-parser' }
           ]
         }
       ],

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -13,3 +13,4 @@ These guides offer non-normative workflows and implementation advice alongside t
 - [Platform guidance](./platform-guidance.md#platform-guidance) collects ecosystem-specific mapping tips.
 - [Migrating from the DTCG format](./migrating-from-dtcg.md#migrating-from-dtcg) walks through porting Design Tokens Community Group documents to DTIF.
 - [Using the DTIF parser](./dtif-parser.md#dtif-parser-guide) explains how to install, configure, and extend the canonical parser.
+- [Tooling built with DTIF](/tooling/) curates reference integrations you can adopt across your workflows.


### PR DESCRIPTION
## Summary
- remove the top-level navigation entry for the Tooling section to avoid linking to the broken parser reference
- keep the tooling docs discoverable by linking them from the Guides overview and trimming the sidebar to published pages
- link the tooling sidebar directly to the published DTIF parser guide now that the API reference is gone

## Testing
- npm run lint:docs

------
https://chatgpt.com/codex/tasks/task_e_68d51b84c6ec8328b524138b2e4c0ba6