### PR TITLE
Group dtif packages in Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "@lapidist/dtif-schema",
+        "@lapidist/dtif-validator",
+        "@lapidist/dtif-parser"
+      ],
+      "groupName": "dtif core packages",
+      "groupSlug": "dtif-core"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- group the dtif core packages under a single Renovate rule
- assign a shared group name and slug for the schema, validator, and parser packages

## Testing
- npm run format:check
- npm run lint
- npm run lint:ts
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5e06fe32083288ab8db37e819d13e