### PR TITLE
Expose analysis update status for language server documents

### DIFF
--- a/language-server/src/core/documents/analyzer.ts
+++ b/language-server/src/core/documents/analyzer.ts
@@ -6,8 +6,7 @@ import { rangeFromNode } from './ranges.js';
 
 const POINTER_REFERENCE_KEYS = new Set(['$ref', 'token', 'ref']);
 
-export function analyzeTextDocument(document: TextDocument): DocumentAnalysis | null {
-  const text = document.getText();
+export function analyzeTextDocument(document: TextDocument, text: string): DocumentAnalysis | null {
   const parseErrors: ParseError[] = [];
   const tree = parseTree(text, parseErrors, {
     allowTrailingComma: false,

--- a/language-server/src/features/completions/index.ts
+++ b/language-server/src/features/completions/index.ts
@@ -48,6 +48,7 @@ export function buildCompletions(options: BuildCompletionsOptions): CompletionIt
   const offset = document.offsetAt(position);
   const location = getLocation(document.getText(), offset);
   const path = location.path;
+  const pointerFromLocation = path.length > 0 ? pathToPointer(path) : '#';
   const activeSegment = path[path.length - 1];
 
   if (activeSegment === '$type') {
@@ -55,7 +56,11 @@ export function buildCompletions(options: BuildCompletionsOptions): CompletionIt
   }
 
   if (activeSegment === 'unit') {
-    return buildUnitCompletionItems(store, document.uri, pointerMatch?.pointer ?? '#');
+    return buildUnitCompletionItems(
+      store,
+      document.uri,
+      pointerMatch?.pointer ?? pointerFromLocation
+    );
   }
 
   if (location.isAtPropertyKey && path[path.length - 1] === '') {

--- a/language-server/tests/analysis-store.test.ts
+++ b/language-server/tests/analysis-store.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { DocumentAnalysisStore } from '../src/core/documents/analysis-store.js';
+
+void test('DocumentAnalysisStore keeps previous analysis when parsing fails', () => {
+  const store = new DocumentAnalysisStore();
+  const uri = 'file:///memory/store.json';
+
+  const validDocument = TextDocument.create(
+    uri,
+    'json',
+    1,
+    '{ "tokens": { "color": { "$type": "color", "$value": { "colorSpace": "srgb" } } } }'
+  );
+
+  const validResult = store.update(validDocument);
+  assert.equal(validResult.ok, true);
+  assert.equal(validResult.status, 'updated');
+  assert.equal(validResult.analysis, store.get(uri));
+
+  const initialAnalysis = store.get(uri);
+  assert.ok(initialAnalysis, 'expected analysis for valid document');
+
+  const invalidDocument = TextDocument.create(
+    uri,
+    'json',
+    2,
+    '{ "tokens": { "color": { "$type": "color", } } }'
+  );
+
+  const invalidResult = store.update(invalidDocument);
+  assert.equal(invalidResult.ok, true);
+  assert.equal(invalidResult.status, 'retained');
+  assert.equal(invalidResult.analysis, initialAnalysis);
+  assert.equal(
+    store.get(uri),
+    initialAnalysis,
+    'expected previous analysis to remain after parse failure'
+  );
+});
+
+void test('DocumentAnalysisStore clears analysis when parsing fails with no previous state', () => {
+  const store = new DocumentAnalysisStore();
+  const uri = 'file:///memory/store.json';
+
+  const invalidDocument = TextDocument.create(uri, 'json', 1, '{ "tokens": { "color": { "');
+
+  const result = store.update(invalidDocument);
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 'cleared');
+  assert.equal(result.analysis, undefined);
+  assert.equal(store.get(uri), undefined, 'expected no analysis to be stored');
+});
+
+void test('DocumentAnalysisStore updates analysis again after a parse failure recovers', () => {
+  const store = new DocumentAnalysisStore();
+  const uri = 'file:///memory/store.json';
+
+  const firstValid = TextDocument.create(
+    uri,
+    'json',
+    1,
+    '{ "tokens": { "size": { "$type": "dimension", "$value": { "dimensionType": "length" } } } }'
+  );
+
+  const firstResult = store.update(firstValid);
+  assert.equal(firstResult.status, 'updated');
+  const firstAnalysis = store.get(uri);
+  assert.ok(firstAnalysis, 'expected initial analysis to exist');
+
+  const invalidDocument = TextDocument.create(
+    uri,
+    'json',
+    2,
+    '{ "tokens": { "size": { "$type": "dimension", "$value": { "dimensionType": "length" }, } } }'
+  );
+
+  const invalidResult = store.update(invalidDocument);
+  assert.equal(invalidResult.status, 'retained');
+  assert.equal(store.get(uri), firstAnalysis);
+
+  const recoveredDocument = TextDocument.create(
+    uri,
+    'json',
+    3,
+    '{ "tokens": { "size": { "$type": "dimension", "$value": { "dimensionType": "angle" } } } }'
+  );
+
+  const recoveredResult = store.update(recoveredDocument);
+  assert.equal(recoveredResult.status, 'updated');
+  const recoveredAnalysis = store.get(uri);
+  assert.ok(recoveredAnalysis, 'expected analysis after recovery');
+  assert.notEqual(recoveredAnalysis, firstAnalysis, 'expected analysis to refresh after recovery');
+});
+
+void test('DocumentAnalysisStore clears stale analysis when document becomes empty', () => {
+  const store = new DocumentAnalysisStore();
+  const uri = 'file:///memory/store.json';
+
+  const validDocument = TextDocument.create(
+    uri,
+    'json',
+    1,
+    '{ "tokens": { "size": { "$type": "dimension", "$value": { "dimensionType": "angle" } } } }'
+  );
+
+  const firstResult = store.update(validDocument);
+  assert.equal(firstResult.status, 'updated');
+  assert.ok(store.get(uri));
+
+  const emptyDocument = TextDocument.create(uri, 'json', 2, '   \n\n   ');
+
+  const clearedResult = store.update(emptyDocument);
+  assert.equal(clearedResult.status, 'cleared');
+  assert.equal(clearedResult.analysis, undefined);
+  assert.equal(store.get(uri), undefined, 'expected analysis to be removed for empty document');
+});


### PR DESCRIPTION
## Summary
- expose explicit DocumentAnalysisStore update statuses and surface the retained analysis when parsing fails
- cover cleared, retained, and recovered analysis flows with regression tests so the cache semantics stay well defined
- treat empty documents as cleared analysis snapshots to avoid surfacing stale completions and reuse the parsed text when analysing

## Testing
- npm run format:check
- npm run lint:ts
- npm run build --workspace=@lapidist/dtif-language-server
- npm test --workspace=@lapidist/dtif-language-server

------
https://chatgpt.com/codex/tasks/task_e_68d84db495208328a89af4880bd90e5a