### PR TITLE
ci: validate markdown dtif examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Lint TypeScript
         run: npm run lint:ts
 
+      - name: Validate DTIF markdown examples
+        run: npm run validate:dtif
+
       - name: Run tests
         run: npm test
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Browse the deployed documentation at **[dtif.lapidist.net](https://dtif.lapidist
 
 ## Quick example
 
-```jsonc
+```json dtif
 {
   "$schema": "https://dtif.lapidist.net/schema/core.json",
   "$version": "1.0.0",

--- a/docs/examples/animation.md
+++ b/docs/examples/animation.md
@@ -11,8 +11,9 @@ See [`animation.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examp
 
 ## Sample tokens {#animation-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "duration": {
     "entry": {
       "$type": "duration",

--- a/docs/examples/border.md
+++ b/docs/examples/border.md
@@ -11,8 +11,9 @@ See [`border.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examples
 
 ## Sample tokens {#border-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "border": {
     "cardOutlineAndroid": {
       "$type": "border",
@@ -88,7 +89,9 @@ See [`border.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examples
           }
         },
         "style": "dashed",
-        "strokeStyle": { "$ref": "#/strokeStyle/cardDashed" },
+        "strokeStyle": {
+          "$ref": "#/strokeStyle/cardDashed"
+        },
         "width": {
           "dimensionType": "length",
           "value": 1.5,

--- a/docs/examples/color-spaces.md
+++ b/docs/examples/color-spaces.md
@@ -11,8 +11,9 @@ See [`color-spaces.tokens.json`](https://github.com/bylapidist/dtif/blob/main/ex
 
 ## Sample tokens {#color-spaces-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "color": {
     "accent": {
       "$type": "color",

--- a/docs/examples/complete.md
+++ b/docs/examples/complete.md
@@ -11,8 +11,9 @@ See [`complete.tokens.json`](https://github.com/bylapidist/dtif/blob/main/exampl
 
 ## Sample tokens {#complete-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "component": {
     "button": {
       "$type": "component",

--- a/docs/examples/complex.md
+++ b/docs/examples/complex.md
@@ -11,10 +11,10 @@ See [`complex.tokens.json`](https://github.com/bylapidist/dtif/blob/main/example
 
 ## Sample tokens {#complex-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "button": {
-    "$type": "color",
     "$extensions": {
       "com.example": {
         "platform": "ios"

--- a/docs/examples/cursor.md
+++ b/docs/examples/cursor.md
@@ -11,8 +11,9 @@ See [`cursor.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examples
 
 ## Sample tokens {#cursor-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "cursor": {
     "link": {
       "$type": "cursor",

--- a/docs/examples/dark.md
+++ b/docs/examples/dark.md
@@ -11,12 +11,12 @@ See [`dark.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examples/d
 
 ## Sample tokens {#dark-sample}
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "color": {
-    "$type": "color",
     "brand": {
+      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [0.8, 0, 0]

--- a/docs/examples/elevation.md
+++ b/docs/examples/elevation.md
@@ -11,8 +11,9 @@ See [`elevation.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examp
 
 ## Sample tokens {#elevation-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "elevation": {
     "surface-android": {
       "$type": "elevation",

--- a/docs/examples/extensions.md
+++ b/docs/examples/extensions.md
@@ -11,8 +11,9 @@ See [`extensions.tokens.json`](https://github.com/bylapidist/dtif/blob/main/exam
 
 ## Sample tokens {#extensions-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "color": {
     "cta": {
       "$type": "color",

--- a/docs/examples/filter.md
+++ b/docs/examples/filter.md
@@ -11,8 +11,9 @@ See [`filter.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examples
 
 ## Sample tokens {#filter-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "filter": {
     "focus-css": {
       "$type": "filter",

--- a/docs/examples/font-face.md
+++ b/docs/examples/font-face.md
@@ -11,8 +11,9 @@ See [`font-face.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examp
 
 ## Sample tokens {#font-face-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "fontFace": {
     "brand": {
       "$type": "fontFace",

--- a/docs/examples/font-scale.md
+++ b/docs/examples/font-scale.md
@@ -11,8 +11,9 @@ See [`font-scale.tokens.json`](https://github.com/bylapidist/dtif/blob/main/exam
 
 ## Sample tokens {#font-scale-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "spacing": {
     "fixed": {
       "$type": "dimension",

--- a/docs/examples/font.md
+++ b/docs/examples/font.md
@@ -11,8 +11,9 @@ See [`font.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examples/f
 
 ## Sample tokens {#font-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "font": {
     "brand": {
       "$type": "font",

--- a/docs/examples/gradients.md
+++ b/docs/examples/gradients.md
@@ -11,8 +11,9 @@ See [`gradients.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examp
 
 ## Sample tokens {#gradients-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "gradient": {
     "heroBackground": {
       "$type": "gradient",
@@ -24,7 +25,7 @@ See [`gradients.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examp
             "position": "0%",
             "color": {
               "colorSpace": "srgb",
-              "components": [0.996, 0.416, 0.0, 1.0]
+              "components": [0.996, 0.416, 0, 1]
             }
           },
           {
@@ -32,14 +33,14 @@ See [`gradients.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examp
             "hint": "50%",
             "color": {
               "colorSpace": "srgb",
-              "components": [1.0, 0.824, 0.0, 1.0]
+              "components": [1, 0.824, 0, 1]
             }
           },
           {
             "position": "calc(100% - 8px)",
             "color": {
               "colorSpace": "srgb",
-              "components": [1.0, 0.0, 0.4, 1.0]
+              "components": [1, 0, 0.4, 1]
             }
           }
         ]
@@ -59,7 +60,7 @@ See [`gradients.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examp
             "position": 0,
             "color": {
               "colorSpace": "srgb",
-              "components": [1.0, 0.973, 0.925, 1.0]
+              "components": [1, 0.973, 0.925, 1]
             }
           },
           {
@@ -67,14 +68,14 @@ See [`gradients.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examp
             "hint": 0.7,
             "color": {
               "colorSpace": "srgb",
-              "components": [1.0, 0.733, 0.565, 0.7]
+              "components": [1, 0.733, 0.565, 0.7]
             }
           },
           {
             "position": 1,
             "color": {
               "colorSpace": "srgb",
-              "components": [0.965, 0.525, 0.29, 0.0]
+              "components": [0.965, 0.525, 0.29, 0]
             }
           }
         ]

--- a/docs/examples/light.md
+++ b/docs/examples/light.md
@@ -11,12 +11,12 @@ See [`light.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examples/
 
 ## Sample tokens {#light-sample}
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "color": {
-    "$type": "color",
     "brand": {
+      "$type": "color",
       "$value": {
         "colorSpace": "srgb",
         "components": [1, 0.2, 0.2]

--- a/docs/examples/minimal.md
+++ b/docs/examples/minimal.md
@@ -11,7 +11,7 @@ See [`minimal.tokens.json`](https://github.com/bylapidist/dtif/blob/main/example
 
 ## Sample tokens {#minimal-sample}
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "spacing": {

--- a/docs/examples/motion.md
+++ b/docs/examples/motion.md
@@ -11,8 +11,9 @@ See [`motion.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examples
 
 ## Sample tokens {#motion-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "android-elevation": {
     "$type": "motion",
     "$value": {

--- a/docs/examples/opacity.md
+++ b/docs/examples/opacity.md
@@ -11,8 +11,9 @@ See [`opacity.tokens.json`](https://github.com/bylapidist/dtif/blob/main/example
 
 ## Sample tokens {#opacity-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "opacity": {
     "layer": {
       "$type": "opacity",

--- a/docs/examples/overrides.md
+++ b/docs/examples/overrides.md
@@ -11,8 +11,9 @@ See [`overrides.tokens.json`](https://github.com/bylapidist/dtif/blob/main/examp
 
 ## Sample tokens {#overrides-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "$overrides": [
     {
       "$token": "#/button/bg",

--- a/docs/examples/shadows.md
+++ b/docs/examples/shadows.md
@@ -11,8 +11,9 @@ See [`shadows.tokens.json`](https://github.com/bylapidist/dtif/blob/main/example
 
 ## Sample tokens {#shadows-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "shadow": {
     "card": {
       "$type": "shadow",

--- a/docs/examples/typography-base.md
+++ b/docs/examples/typography-base.md
@@ -11,8 +11,9 @@ See [`typography-base.tokens.json`](https://github.com/bylapidist/dtif/blob/main
 
 ## Sample tokens {#typography-base-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "typography": {
     "body": {
       "$type": "typography",

--- a/docs/examples/typography-complete.md
+++ b/docs/examples/typography-complete.md
@@ -11,8 +11,9 @@ See [`typography-complete.tokens.json`](https://github.com/bylapidist/dtif/blob/
 
 ## Sample tokens {#typography-complete-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "typography": {
     "body": {
       "$type": "typography",

--- a/docs/examples/typography-grammars.md
+++ b/docs/examples/typography-grammars.md
@@ -11,8 +11,9 @@ See [`typography-grammars.tokens.json`](https://github.com/bylapidist/dtif/blob/
 
 ## Sample tokens {#typography-grammars-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "typography": {
     "cssGrammar": {
       "$type": "typography",

--- a/docs/examples/typography-layer.md
+++ b/docs/examples/typography-layer.md
@@ -11,8 +11,9 @@ See [`typography-layer.tokens.json`](https://github.com/bylapidist/dtif/blob/mai
 
 ## Sample tokens {#typography-layer-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "typography": {
     "body": {
       "$value": {

--- a/docs/examples/typography-line-height.md
+++ b/docs/examples/typography-line-height.md
@@ -11,8 +11,9 @@ See [`typography-line-height.tokens.json`](https://github.com/bylapidist/dtif/bl
 
 ## Sample tokens {#typography-line-height-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "typography": {
     "absolutePx": {
       "$type": "typography",

--- a/docs/examples/typography-optional-properties.md
+++ b/docs/examples/typography-optional-properties.md
@@ -11,8 +11,9 @@ See [`typography-optional-properties.tokens.json`](https://github.com/bylapidist
 
 ## Sample tokens {#typography-optional-properties-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "typography": {
     "body": {
       "$type": "typography",

--- a/docs/examples/typography-units.md
+++ b/docs/examples/typography-units.md
@@ -11,8 +11,9 @@ See [`typography-units.tokens.json`](https://github.com/bylapidist/dtif/blob/mai
 
 ## Sample tokens {#typography-units-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "typography": {
     "ch": {
       "$type": "typography",

--- a/docs/examples/z-index.md
+++ b/docs/examples/z-index.md
@@ -11,8 +11,9 @@ See [`z-index.tokens.json`](https://github.com/bylapidist/dtif/blob/main/example
 
 ## Sample tokens {#z-index-sample}
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "z-index": {
     "android-fab": {
       "$type": "z-index",

--- a/docs/guides/dtif-parser.md
+++ b/docs/guides/dtif-parser.md
@@ -89,10 +89,13 @@ The synchronous variant consumes inline content without touching the filesystem.
 import { parseTokensSync } from '@lapidist/dtif-parser';
 
 const { flattened } = parseTokensSync({
-  $schema: 'https://dtif.lapidist.net/schema.json',
-  values: {
-    color: {
-      brand: { primary: { $type: 'color', $value: '#0055ff' } }
+  $schema: 'https://dtif.lapidist.net/schema/core.json',
+  color: {
+    brand: {
+      primary: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0.3333, 1] }
+      }
     }
   }
 });
@@ -105,7 +108,7 @@ console.log(flattened[0]);
 The helpers above accept inline DTIF objects in addition to file paths. The following document is valid against the
 [core schema](https://dtif.lapidist.net/schema/core.json) and demonstrates a small hierarchy, metadata, and an alias:
 
-```json
+```json dtif
 {
   "$schema": "https://dtif.lapidist.net/schema/core.json",
   "$version": "1.0.0",

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -8,11 +8,18 @@ outline: [2, 3]
 
 Token documents are UTF-8 encoded JSON files. The following example is valid:
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "spacing": {
-    "small": { "$type": "dimension", "$value": { "value": 2, "unit": "px" } }
+    "small": {
+      "$type": "dimension",
+      "$value": {
+        "dimensionType": "length",
+        "value": 2,
+        "unit": "px"
+      }
+    }
   }
 }
 ```

--- a/docs/guides/migrating-from-dtcg.md
+++ b/docs/guides/migrating-from-dtcg.md
@@ -102,7 +102,7 @@ emit members such as `$category` to use `$extensions` before converting them to 
 
 #### DTIF structure (`examples/dtcg-migration/data-model.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "button": {
@@ -322,7 +322,7 @@ DTIF conversion:
 
 #### DTIF merged document (`examples/dtcg-migration/document-shell.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "$description": "Marketing theme converted from split DTCG files.",
@@ -411,7 +411,7 @@ DTIF reuses familiar fields and introduces additional lifecycle tracking:
 
 #### DTIF metadata (`examples/dtcg-migration/metadata.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "status": {
@@ -476,7 +476,7 @@ The table below summarises how the DTCG primitive types map to DTIF.
 
 #### DTIF color token (`examples/dtcg-migration/color.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "color": {
@@ -516,7 +516,7 @@ to preserve CSS-oriented serialisations without `$extensions`.
 
 #### DTIF dimensions (`examples/dtcg-migration/dimension.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "dimension": {
@@ -570,7 +570,7 @@ keeping the numeric payloads intact.
 
 #### DTIF temporal tokens (`examples/dtcg-migration/duration-easing.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "duration": {
@@ -669,7 +669,7 @@ before importing them into DTIF.
 
 #### DTIF typography (`examples/dtcg-migration/typography.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "font": {
@@ -685,7 +685,7 @@ before importing them into DTIF.
     }
   },
   "dimension": {
-    "shared": {
+    "typography": {
       "body-size": {
         "$type": "dimension",
         "$value": {
@@ -709,20 +709,6 @@ before importing them into DTIF.
           "value": 24,
           "unit": "px"
         }
-      }
-    },
-    "typography": {
-      "body-size": {
-        "$type": "dimension",
-        "$ref": "#/dimension/shared/body-size"
-      },
-      "body-letter-spacing": {
-        "$type": "dimension",
-        "$ref": "#/dimension/shared/body-letter-spacing"
-      },
-      "body-line-height": {
-        "$type": "dimension",
-        "$ref": "#/dimension/shared/body-line-height"
       }
     }
   },
@@ -962,7 +948,7 @@ richer schemas for these structures.
 
 #### DTIF border (`examples/dtcg-migration/border.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "color": {
@@ -984,6 +970,18 @@ richer schemas for these structures.
       }
     }
   },
+  "border": {
+    "focus-outline": {
+      "$type": "border",
+      "$value": {
+        "borderType": "css.border",
+        "color": { "$ref": "#/color/focus-outline" },
+        "style": "solid",
+        "strokeStyle": { "$ref": "#/strokeStyle/focus" },
+        "width": { "$ref": "#/dimension/focus-outline-width" }
+      }
+    }
+  },
   "strokeStyle": {
     "focus": {
       "$type": "strokeStyle",
@@ -1001,18 +999,6 @@ richer schemas for these structures.
           }
         ],
         "lineCap": "round"
-      }
-    }
-  },
-  "border": {
-    "focus-outline": {
-      "$type": "border",
-      "$value": {
-        "borderType": "css.border",
-        "color": { "$ref": "#/color/focus-outline" },
-        "style": "solid",
-        "strokeStyle": { "$ref": "#/strokeStyle/focus" },
-        "width": { "$ref": "#/dimension/focus-outline-width" }
       }
     }
   }
@@ -1111,7 +1097,7 @@ validation noise-free.
 
 #### DTIF shadow (`examples/dtcg-migration/shadow.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "color": {
@@ -1250,7 +1236,7 @@ matches the original DTCG payload.
 
 #### DTIF gradient (`examples/dtcg-migration/gradient.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "color": {
@@ -1405,7 +1391,7 @@ DTIF conversion with CSS-compliant strings:
 
 #### DTIF transition (`examples/dtcg-migration/transition.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "duration": {
@@ -1497,7 +1483,7 @@ Migrating is an opportunity to adopt DTIF-only capabilities:
 
 #### DTIF component token (`examples/dtcg-migration/component.tokens.json`)
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "color": {

--- a/docs/spec/metadata.md
+++ b/docs/spec/metadata.md
@@ -38,21 +38,26 @@ ratios or user preference qualifiers (for example `prefers-reduced-motion`).
 Tools _SHOULD_ use these hints to enforce inclusive design while
 continuing to honour the underlying token semantics.
 
-```json
+```json dtif
 {
-  "link-color": {
-    "$type": "color",
-    "$value": { "colorSpace": "srgb", "components": [0, 0, 1] },
-    "$extensions": { "org.example.a11y": { "wcagContrast": 4.5 } }
+  "$version": "1.0.0",
+  "color": {
+    "link": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [0, 0, 1] },
+      "$extensions": { "org.example.a11y": { "wcagContrast": 4.5 } }
+    }
   },
-  "fade-duration": {
-    "$type": "duration",
-    "$value": {
-      "durationType": "css.transition-duration",
-      "value": 200,
-      "unit": "ms"
-    },
-    "$extensions": { "org.example.a11y": { "prefers-reduced-motion": true } }
+  "duration": {
+    "fade": {
+      "$type": "duration",
+      "$value": {
+        "durationType": "css.transition-duration",
+        "value": 200,
+        "unit": "ms"
+      },
+      "$extensions": { "org.example.a11y": { "prefers-reduced-motion": true } }
+    }
   }
 }
 ```
@@ -63,11 +68,16 @@ Extensions _MAY_ attach intent descriptors to tokens (for example
 `primary action` or `neutral surface`) so that automation and
 machine-learning systems can reason about design intent.
 
-```json
+```json dtif
 {
-  "$type": "color",
-  "$value": { "colorSpace": "srgb", "components": [0, 0.5, 1] },
-  "$extensions": { "org.example.ai": { "intent": "primary action" } }
+  "$version": "1.0.0",
+  "color": {
+    "action": {
+      "$type": "color",
+      "$value": { "colorSpace": "srgb", "components": [0, 0.5, 1] },
+      "$extensions": { "org.example.ai": { "intent": "primary action" } }
+    }
+  }
 }
 ```
 

--- a/docs/spec/typography.md
+++ b/docs/spec/typography.md
@@ -40,7 +40,7 @@ See [Token types](./token-types.md#value) for shared `$value` requirements that 
 Minimal typography tokens define only `fontFamily` and `fontSize`.
 Additional properties _MAY_ be layered to build complete styles.
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "typography": {
@@ -55,7 +55,7 @@ Additional properties _MAY_ be layered to build complete styles.
 }
 ```
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "typography": {
@@ -66,7 +66,7 @@ Additional properties _MAY_ be layered to build complete styles.
 }
 ```
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "typography": {
@@ -129,7 +129,7 @@ tokens whose `$value.dimensionType` is `"length"`, while `color` references _MUS
 `color` tokens. Consumers _MUST_ reject `$ref` targets that do not meet these
 requirements so typography tokens remain well-typed composites.
 
-```json
+```json dtif
 {
   "$version": "1.0.0",
   "dimension": {
@@ -182,19 +182,24 @@ _Table: Normative references for typography members._
 | `textTransform`   | `text-transform`, NSStringTransform, Java String case conversion                                                                                       |
 | `fontFeatures`    | `font-feature-settings`, OpenType feature registry                                                                                                     |
 
-```json
+```json dtif
 {
-  "$type": "typography",
-  "$value": {
-    "fontFamily": "Inter",
-    "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
-    "lineHeight": 1.5,
-    "letterSpacing": { "dimensionType": "length", "value": 0.5, "unit": "px" },
-    "wordSpacing": { "dimensionType": "length", "value": 2, "unit": "px" },
-    "color": { "colorSpace": "srgb", "components": [0.2, 0.25, 0.3, 1] },
-    "textDecoration": "underline",
-    "textTransform": "uppercase",
-    "fontFeatures": ["smcp", "liga"]
+  "$version": "1.0.0",
+  "typography": {
+    "body": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Inter",
+        "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
+        "lineHeight": 1.5,
+        "letterSpacing": { "dimensionType": "length", "value": 0.5, "unit": "px" },
+        "wordSpacing": { "dimensionType": "length", "value": 2, "unit": "px" },
+        "color": { "colorSpace": "srgb", "components": [0.2, 0.25, 0.3, 1] },
+        "textDecoration": "underline",
+        "textTransform": "uppercase",
+        "fontFeatures": ["smcp", "liga"]
+      }
+    }
   }
 }
 ```
@@ -288,12 +293,18 @@ The `lineHeight` value _MUST_ represent the
 baseline-to-baseline distance between lines of text. Additional leading above or below
 this region is not part of the measurement.
 
-```json
+```json dtif
 {
-  "$type": "typography",
-  "$value": {
-    "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
-    "lineHeight": 1.5
+  "$version": "1.0.0",
+  "typography": {
+    "body": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Inter",
+        "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
+        "lineHeight": 1.5
+      }
+    }
   }
 }
 ```
@@ -414,13 +425,18 @@ platform's `1`-`1000` range when necessary. Web consumers
 _MUST_ apply the CSS weight resolution algorithm when cascading
 values through the DOM.
 
-```json
+```json dtif
 {
-  "$type": "typography",
-  "$value": {
-    "fontFamily": "Inter",
-    "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
-    "fontWeight": 700
+  "$version": "1.0.0",
+  "typography": {
+    "heading": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Inter",
+        "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
+        "fontWeight": 700
+      }
+    }
   }
 }
 ```
@@ -448,13 +464,18 @@ Typeface.Builder#setFontVariationSettings. Fonts
 that omit a `slnt` axis _MAY_ fall back to italic traits
 while preserving the authored angle for downstream consumers.
 
-```json
+```json dtif
 {
-  "$type": "typography",
-  "$value": {
-    "fontFamily": "Inter",
-    "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
-    "fontStyle": "oblique -12deg"
+  "$version": "1.0.0",
+  "typography": {
+    "italic": {
+      "$type": "typography",
+      "$value": {
+        "fontFamily": "Inter",
+        "fontSize": { "dimensionType": "length", "value": 16, "unit": "px" },
+        "fontStyle": "oblique -12deg"
+      }
+    }
   }
 }
 ```
@@ -584,8 +605,9 @@ registration metadata stay aligned across CSS, iOS, and Android implementations.
 | `fontFace.$value.unicodeRange` | `unicode-range`                                                                                                                                        |
 | `fontFace.$value.fontDisplay`  | `font-display`                                                                                                                                         |
 
-```json
+```json dtif
 {
+  "$version": "1.0.0",
   "fontFace": {
     "brand": {
       "$type": "fontFace",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "markdownlint \"**/*.md\" --ignore \"**/node_modules/**\"",
     "lint:fix": "markdownlint --fix \"**/*.md\" --ignore \"**/node_modules/**\"",
     "lint:ts": "eslint .",
+    "validate:dtif": "node scripts/validate-markdown-dtif.mjs",
     "build": "npm run build:packages",
     "build:packages": "node scripts/build-packages.mjs",
     "docs:dev": "vitepress dev docs",

--- a/scripts/validate-markdown-dtif.mjs
+++ b/scripts/validate-markdown-dtif.mjs
@@ -1,0 +1,91 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { execFile as execFileCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import { validateDtif } from '../validator/index.js';
+
+const execFile = promisify(execFileCallback);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const { stdout } = await execFile('git', ['ls-files', 'README.md', 'docs/**/*.md'], {
+  cwd: repoRoot
+});
+
+const files = stdout
+  .split('\n')
+  .map((line) => line.trim())
+  .filter(Boolean)
+  .map((relativePath) => path.join(repoRoot, relativePath));
+
+const codeFencePattern = /```([^\n]*)\n([\s\S]*?)```/g;
+
+const failures = [];
+const successes = [];
+
+for (const file of files) {
+  const text = await readFile(file, 'utf8');
+  let match;
+  let index = 0;
+  while ((match = codeFencePattern.exec(text)) !== null) {
+    index += 1;
+    const [, infoStringRaw, rawContent] = match;
+    const infoString = infoStringRaw.trim();
+    const infoTokens = infoString.split(/\s+/).filter(Boolean);
+    const hasDtifTag = infoTokens.includes('dtif');
+    if (!hasDtifTag) {
+      continue;
+    }
+
+    const cleaned = rawContent
+      .replace(/\r\n?/g, '\n')
+      .split('\n')
+      .filter((line) => !/^\s*\/\//.test(line))
+      .join('\n')
+      .replace(/\/\*[\s\S]*?\*\//g, '');
+
+    let parsed;
+    try {
+      parsed = JSON.parse(cleaned);
+    } catch (error) {
+      failures.push({
+        file,
+        index,
+        errors: [{ instancePath: '<parse>', message: `Failed to parse JSON: ${error.message}` }]
+      });
+      continue;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      failures.push({
+        file,
+        index,
+        errors: [{ instancePath: '<root>', message: 'DTIF example must be a JSON object' }]
+      });
+      continue;
+    }
+
+    const result = validateDtif(parsed);
+    if (!result.valid) {
+      failures.push({ file, index, errors: result.errors });
+    } else {
+      successes.push({ file, index });
+    }
+  }
+}
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    const relativePath = path.relative(repoRoot, failure.file);
+    console.error(`Validation failed for ${relativePath} (code block #${failure.index}):`);
+    for (const error of failure.errors ?? []) {
+      console.error(`  [${error.instancePath || '<root>'}] ${error.message}`);
+    }
+  }
+  process.exitCode = 1;
+} else {
+  console.log(`Validated ${successes.length} DTIF example(s).`);
+}


### PR DESCRIPTION
## Summary
- add a utility that validates dtif-tagged markdown code fences against the schema
- annotate README and documentation samples with dtif tags and schema-compliant payloads
- refresh guide and spec examples to reflect valid DTIF structures
- run the markdown DTIF validation script in CI via a dedicated npm script

## Testing
- CI=1 npm run format:check
- npm run lint
- npm run lint:docs
- npm run lint:ts
- npm test
- npm run validate:dtif

------
https://chatgpt.com/codex/tasks/task_e_68e2fe0ad47883288b7f7a47f95bbaf6