### PR TITLE
chore(v8): align renovate.json with workspace standard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,23 @@
   "extends": ["config:recommended"],
   "automerge": true,
   "automergeType": "pr",
+  "platformAutomerge": true,
+  "rangeStrategy": "pin",
+  "constraints": {
+    "node": ">=22"
+  },
   "packageRules": [
     {
+      "description": "Keep engines.node as \">=22\" and prevent bumps to 23/24",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "matchPackageNames": ["node"],
+      "allowedVersions": ">=22 <23",
+      "rangeStrategy": "replace"
+    },
+    {
+      "description": "Update DTIF packages together",
+      "matchManagers": ["npm"],
       "matchPackageNames": [
         "@lapidist/dtif-schema",
         "@lapidist/dtif-validator",


### PR DESCRIPTION
## Summary

- Add `platformAutomerge`, `rangeStrategy: pin`, `node >=22` constraint, and node engine version guard to match the workspace-wide renovate standard set in dsr, dscp, and eslint-config.

## Part of
ROADMAP.md v8 — dtif Phase 5 tracking branch

## Test plan
- [ ] CI passes on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)