### PR TITLE
chore(v8): migrate to shared @lapidist/eslint-config and pin dependencies

### DIFF
--- a/.changeset/shared-eslint-config.md
+++ b/.changeset/shared-eslint-config.md
@@ -1,0 +1,5 @@
+---
+'@lapidist/dtif': patch
+---
+
+migrate to shared @lapidist/eslint-config and pin all dependency versions

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,35 +1,16 @@
-import tsPlugin from '@typescript-eslint/eslint-plugin';
-import tsParser from '@typescript-eslint/parser';
+import { createConfig } from '@lapidist/eslint-config';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const tsconfigRootDir = dirname(fileURLToPath(import.meta.url));
-
 export default [
-  {
+  ...createConfig({
+    tsconfigRootDir: dirname(fileURLToPath(import.meta.url)),
     ignores: ['tests/fixtures/**']
-  },
+  }),
   {
-    files: ['**/*.ts', '**/*.tsx'],
-    languageOptions: {
-      parser: tsParser,
-      parserOptions: {
-        project: './tsconfig.eslint.json',
-        tsconfigRootDir
-      }
-    },
-    plugins: { '@typescript-eslint': tsPlugin },
+    files: ['**/*.ts'],
     rules: {
-      ...tsPlugin.configs['strict-type-checked'].rules,
-      ...tsPlugin.configs['stylistic-type-checked'].rules,
-      '@typescript-eslint/no-require-imports': 'off',
-      '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }]
-    }
-  },
-  {
-    files: ['tests/**/*.ts', 'tests/**/*.tsx'],
-    rules: {
-      '@typescript-eslint/consistent-type-assertions': 'off'
+      '@typescript-eslint/no-require-imports': 'off'
     }
   },
   {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@changesets/changelog-github": "0.6.0",
     "@changesets/cli": "2.30.0",
     "@dtsgenerator/replace-namespace": "1.7.0",
+    "@lapidist/eslint-config": "1.0.0",
     "@types/node": "24.12.2",
     "@typescript-eslint/eslint-plugin": "8.58.2",
     "@typescript-eslint/parser": "8.58.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@dtsgenerator/replace-namespace':
         specifier: 1.7.0
         version: 1.7.0(dtsgenerator@3.19.2)(tslib@2.8.1)
+      '@lapidist/eslint-config':
+        specifier: 1.0.0
+        version: 1.0.0(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(@typescript-eslint/parser@8.58.2(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
@@ -677,6 +680,14 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@lapidist/eslint-config@1.0.0':
+    resolution: {integrity: sha512-WIBO41HOsWEeL443gCoTbp2bCkP7XXhlvR/4vzmMJ+Hw2Dh+qrMiSVS9FA5I1XIOjCvM4vrg+fMfK14Yq2fkfg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': '>=8'
+      '@typescript-eslint/parser': '>=8'
+      eslint: '>=9'
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -3030,6 +3041,12 @@ snapshots:
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@lapidist/eslint-config@1.0.0(@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3))(@typescript-eslint/parser@8.58.2(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)':
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0)(typescript@5.9.3))(eslint@10.2.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.2(eslint@10.2.0)(typescript@5.9.3)
+      eslint: 10.2.0
 
   '@manypkg/find-root@1.1.0':
     dependencies:


### PR DESCRIPTION
## Summary

- Replace bespoke `eslint.config.js` with `@lapidist/eslint-config` shared config via `createConfig()`
- Preserve dtif-specific overrides: `no-require-imports: off`, `no-restricted-imports` guards on parser internals
- Pin all dependency versions to exact installed values (no `^` or `~` ranges)
- Update lockfile

## Test plan

- [ ] `pnpm run lint:ts` — ESLint passes with zero errors
- [ ] `pnpm run format:check` — Prettier check passes
- [ ] `pnpm run lint` — markdownlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)