### PR TITLE
fix: remove invalid changeset targeting private root package

### DIFF
--- a/.changeset/shared-eslint-config.md
+++ b/.changeset/shared-eslint-config.md
@@ -1,5 +1,0 @@
----
-'@lapidist/dtif': patch
----
-
-migrate to shared @lapidist/eslint-config and pin all dependency versions


### PR DESCRIPTION
## Summary

- Deletes `.changeset/shared-eslint-config.md` which referenced `@lapidist/dtif` (the private root package)
- Changesets does not recognise the root private package as a workspace package, causing the release CI workflow to fail with: `Error: Found changeset shared-eslint-config for package @lapidist/dtif which is not in the workspace`

## Test plan

- [ ] Confirm the `changesets/action` CI step passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)